### PR TITLE
Add GitHub Actions CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-
 
+      - name: Patch freeze for Windows zlib (use bundled-c-zlib, no pkg-config)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i 's/zlib -bundled-c-zlib +non-blocking-ffi +pkg-config/zlib +bundled-c-zlib +non-blocking-ffi -pkg-config/' cabal.project.freeze
+          grep '^             zlib ' cabal.project.freeze
+
       - run: cabal update
       - run: cabal build all --enable-tests
       - run: cabal test all --test-show-details=streaming

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Disable autocrlf (Windows) so golden fixtures keep LF
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@v4
 
       - id: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches: ['**']
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        # haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.10'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - run: cabal update
+      - run: cabal build all --enable-tests
+      - run: cabal test all --test-show-details=streaming

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,247 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        # haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.10'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - run: cabal update
+      - run: cabal build all --enable-tests
+      - run: cabal test all --test-show-details=streaming
+
+  build-linux:
+    name: build linux ${{ matrix.arch }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-latest
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        # haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.10'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.arch }}-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - run: cabal update
+      - run: cabal build exe:paninfraspec-gen
+
+      - name: Install fpm and rpmbuild
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rpm
+          sudo gem install --no-document fpm
+
+      - name: Package .deb and .rpm
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          BIN=$(cabal list-bin exe:paninfraspec-gen)
+          mkdir -p staging/usr/local/bin
+          cp "$BIN" staging/usr/local/bin/paninfraspec-gen
+          strip staging/usr/local/bin/paninfraspec-gen
+          mkdir -p out
+          for fmt in deb rpm; do
+            fpm -s dir -t "$fmt" \
+                -n paninfraspec \
+                -v "$VERSION" \
+                -a ${{ matrix.arch }} \
+                --license MIT \
+                --description 'Multi-input/multi-output compiler for infra specs (Serverspec generator)' \
+                --url "https://github.com/${{ github.repository }}" \
+                -p out/ \
+                -C staging .
+          done
+          ls -la out/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.arch }}
+          path: out/*
+          if-no-files-found: error
+
+  build-macos:
+    name: build macos ${{ matrix.arch }}
+    needs: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: macos-13
+          - arch: arm64
+            runner: macos-14
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        # haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.10'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-${{ matrix.arch }}-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.arch }}-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - run: cabal update
+      - run: cabal build exe:paninfraspec-gen
+
+      - name: Package tarball
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME="paninfraspec-${VERSION}-darwin-${{ matrix.arch }}"
+          BIN=$(cabal list-bin exe:paninfraspec-gen)
+          mkdir -p "$NAME/bin"
+          cp "$BIN" "$NAME/bin/paninfraspec-gen"
+          strip "$NAME/bin/paninfraspec-gen"
+          cp LICENSE README.md "$NAME"/
+          mkdir -p out
+          tar -czf "out/$NAME.tar.gz" "$NAME"
+          ls -la out/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.arch }}
+          path: out/*
+          if-no-files-found: error
+
+  build-windows:
+    name: build windows x86_64
+    needs: test
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: setup
+        # haskell-actions/setup@v2.11.0
+        uses: haskell-actions/setup@cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553
+        with:
+          ghc-version: '9.6.7'
+          cabal-version: '3.10'
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.setup.outputs.cabal-store }}
+            dist-newstyle
+          key: ${{ runner.os }}-x86_64-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
+          restore-keys: |
+            ${{ runner.os }}-x86_64-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - run: cabal update
+      - run: cabal build exe:paninfraspec-gen
+
+      - name: Package zip
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME="paninfraspec-${VERSION}-windows-x86_64"
+          BIN=$(cabal list-bin exe:paninfraspec-gen)
+          mkdir -p "$NAME"
+          cp "$BIN" "$NAME/paninfraspec-gen.exe"
+          cp LICENSE README.md "$NAME"/
+          # Bundle non-system runtime DLLs (mingw / ghc) detected via ldd from Git Bash.
+          # System DLLs under /c/Windows are excluded.
+          ldd "$BIN" | awk '/=>/ && $3 !~ /^\/c\/[Ww]indows/ {print $3}' | sort -u | while read -r dll; do
+            if [ -f "$dll" ]; then
+              cp "$dll" "$NAME"/
+            fi
+          done
+          mkdir -p out
+          7z a "out/$NAME.zip" "$NAME" >/dev/null
+          ls -la out/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: windows-x86_64
+          path: out/*
+          if-no-files-found: error
+
+  release:
+    name: create github release
+    needs: [build-linux, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: List downloaded assets
+        run: ls -la dist/
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=( dist/*.deb dist/*.rpm dist/*.tar.gz dist/*.zip )
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No release assets found in dist/" >&2
+            exit 1
+          fi
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --generate-notes \
+            "${assets[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Disable autocrlf (Windows) so golden fixtures keep LF
+        if: runner.os == 'Windows'
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@v4
 
       - id: setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-ghc${{ steps.setup.outputs.ghc-version }}-
 
+      - name: Patch freeze for Windows zlib (use bundled-c-zlib, no pkg-config)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i 's/zlib -bundled-c-zlib +non-blocking-ffi +pkg-config/zlib +bundled-c-zlib +non-blocking-ffi -pkg-config/' cabal.project.freeze
+          grep '^             zlib ' cabal.project.freeze
+
       - run: cabal update
       - run: cabal build all --enable-tests
       - run: cabal test all --test-show-details=streaming
@@ -182,6 +190,13 @@ jobs:
           key: ${{ runner.os }}-x86_64-ghc${{ steps.setup.outputs.ghc-version }}-${{ hashFiles('**/cabal.project.freeze', '**/*.cabal') }}
           restore-keys: |
             ${{ runner.os }}-x86_64-ghc${{ steps.setup.outputs.ghc-version }}-
+
+      - name: Patch freeze for Windows zlib (use bundled-c-zlib, no pkg-config)
+        shell: bash
+        run: |
+          set -euo pipefail
+          sed -i 's/zlib -bundled-c-zlib +non-blocking-ffi +pkg-config/zlib +bundled-c-zlib +non-blocking-ffi -pkg-config/' cabal.project.freeze
+          grep '^             zlib ' cabal.project.freeze
 
       - run: cabal update
       - run: cabal build exe:paninfraspec-gen


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` — runs `cabal test all` on push and PR across `ubuntu-latest`, `macos-latest`, `windows-latest` with GHC 9.6.7 and a cached cabal store.
- Add `.github/workflows/release.yml` — triggers on `v*` tags. Runs the same test matrix, then in parallel builds:
  - Linux `.deb` + `.rpm` for x86_64 (`ubuntu-latest`) and aarch64 (`ubuntu-24.04-arm`) via `fpm`.
  - macOS `.tar.gz` for x86_64 (`macos-13`) and arm64 (`macos-14`).
  - Windows `.zip` for x86_64 (`windows-latest`) with mingw runtime DLLs detected via `ldd`.
- Aggregates artifacts and publishes them with `gh release create --generate-notes` (no third-party release-upload action).
- Only one non-official action is used: `haskell-actions/setup`, pinned to the v2.11.0 commit SHA `cd0d9bdd65b20557f41bea4dbe43d0b5fbbfe553`. All other steps use official `actions/*` actions or pre-installed CLIs.

## Test plan
- [ ] Open this PR and confirm the `CI` workflow runs the `test` matrix on all 3 OSes.
- [ ] Push a pre-release tag (e.g. `git tag v0.1.0-rc1 && git push origin v0.1.0-rc1`) and confirm:
  - [ ] `Release` workflow's `test` matrix passes.
  - [ ] `build-linux` produces `paninfraspec_<ver>_amd64.deb`, `paninfraspec-<ver>-1.x86_64.rpm`, plus the aarch64 equivalents.
  - [ ] `build-macos` produces `paninfraspec-<ver>-darwin-x86_64.tar.gz` and `…-darwin-arm64.tar.gz`.
  - [ ] `build-windows` produces `paninfraspec-<ver>-windows-x86_64.zip` containing `paninfraspec-gen.exe`.
  - [ ] GitHub Release lists all 7 assets with auto-generated notes.
- [ ] Smoke-test one asset locally (e.g. `dpkg -i paninfraspec_*_amd64.deb && paninfraspec-gen --help`), then delete the rc tag/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)