### PR TITLE
Add 9 network resources to Serverspec backend (PR 1/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,15 @@ matching `*State` union.
 | Mount | `mount : Text -> MountState -> Assertion` | `Mounted`, `OnDevice : Text`, `OfFstype : Text` |
 | Interface | `interface : Text -> InterfaceState -> Assertion` | `Exist`, `HasSpeed : Natural`, `HasIpv4Address : Text` |
 | Kernel module | `kernelModule : Text -> KernelModuleState -> Assertion` | `Loaded` |
+| Bond | `bond : Text -> BondState -> Assertion` | `Exist`, `HasInterface : Text` |
+| Bridge | `bridge : Text -> BridgeState -> Assertion` | `Exist`, `HasInterface : Text` |
+| Default gateway (singleton) | `defaultGateway : DefaultGatewayState -> Assertion` | `HasIpaddress : Text`, `HasInterface : Text` |
+| Host | `host : Text -> HostState -> Assertion` | `Resolvable`, `Reachable`, `HasIpaddress : Text` |
+| iptables | `iptables : Text -> IptablesState -> Assertion` | `HasRule : Text` |
+| ip6tables | `ip6tables : Text -> Ip6tablesState -> Assertion` | `HasRule : Text` |
+| ipfilter | `ipfilter : Text -> IpfilterState -> Assertion` | `HasRule : Text` |
+| ipnat | `ipnat : Text -> IpnatState -> Assertion` | `HasRule : Text` |
+| Routing table (singleton) | `routingTable : RoutingTableState -> Assertion` | `HasEntry : { destination : Text, gateway : Text }` |
 
 To express more than one state for the same resource (e.g. nginx must be both
 running and enabled), write two assertions with the same primary key — they

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -53,6 +53,27 @@ let InterfaceState =
       >
 let KernelModuleState = < Loaded >
 
+-- PR-1 network resources -----------------------------------------------------
+
+let BondState   = < Exist | HasInterface : Text >
+let BridgeState = < Exist | HasInterface : Text >
+let DefaultGatewayState =
+      < HasIpaddress : Text
+      | HasInterface : Text
+      >
+let HostState =
+      < Resolvable
+      | Reachable
+      | HasIpaddress : Text
+      >
+let Ip6tablesState = < HasRule : Text >
+let IpfilterState  = < HasRule : Text >
+let IpnatState     = < HasRule : Text >
+let IptablesState  = < HasRule : Text >
+let RoutingTableState =
+      < HasEntry : { destination : Text, gateway : Text } >
+
+
 -- Attribute encoders --------------------------------------------------------
 
 let serviceStateAttrs =
@@ -136,6 +157,78 @@ let interfaceStateAttrs =
 let kernelModuleStateAttrs =
       \(_ : KernelModuleState) -> toMap { loaded = AttrValue.AVBool True }
 
+let bondStateAttrs =
+      \(s : BondState) ->
+        merge
+          { Exist        = toMap { exist = AttrValue.AVBool True }
+          , HasInterface = \(i : Text) -> toMap { interface = AttrValue.AVText i }
+          }
+          s
+
+let bridgeStateAttrs =
+      \(s : BridgeState) ->
+        merge
+          { Exist        = toMap { exist = AttrValue.AVBool True }
+          , HasInterface = \(i : Text) -> toMap { interface = AttrValue.AVText i }
+          }
+          s
+
+let defaultGatewayStateAttrs =
+      \(s : DefaultGatewayState) ->
+        merge
+          { HasIpaddress = \(a : Text) -> toMap { ipaddress = AttrValue.AVText a }
+          , HasInterface = \(i : Text) -> toMap { interface = AttrValue.AVText i }
+          }
+          s
+
+let hostStateAttrs =
+      \(s : HostState) ->
+        merge
+          { Resolvable   = toMap { resolvable = AttrValue.AVBool True }
+          , Reachable    = toMap { reachable  = AttrValue.AVBool True }
+          , HasIpaddress = \(a : Text) -> toMap { ipaddress = AttrValue.AVText a }
+          }
+          s
+
+let ip6tablesStateAttrs =
+      \(s : Ip6tablesState) ->
+        merge
+          { HasRule = \(r : Text) -> toMap { rule = AttrValue.AVText r } }
+          s
+
+let ipfilterStateAttrs =
+      \(s : IpfilterState) ->
+        merge
+          { HasRule = \(r : Text) -> toMap { rule = AttrValue.AVText r } }
+          s
+
+let ipnatStateAttrs =
+      \(s : IpnatState) ->
+        merge
+          { HasRule = \(r : Text) -> toMap { rule = AttrValue.AVText r } }
+          s
+
+let iptablesStateAttrs =
+      \(s : IptablesState) ->
+        merge
+          { HasRule = \(r : Text) -> toMap { rule = AttrValue.AVText r } }
+          s
+
+-- routing_table is a wildcard kind: each HasEntry produces one (destination,
+-- gateway) attribute pair, where the destination becomes the dynamic mapKey.
+-- toMap cannot be used here because the field name is value-dependent.
+let routingTableStateAttrs =
+      \(s : RoutingTableState) ->
+        merge
+          { HasEntry =
+              \(e : { destination : Text, gateway : Text }) ->
+                [ { mapKey = e.destination
+                  , mapValue = AttrValue.AVText e.gateway
+                  }
+                ]
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -204,6 +297,69 @@ let kernelModule
       \(s : KernelModuleState) ->
         { kind = "kernel-module", primaryKey = name, attrs = kernelModuleStateAttrs s }
 
+let bond
+    : Text -> BondState -> Assertion
+    = \(name : Text) ->
+      \(s : BondState) ->
+        { kind = "bond", primaryKey = name, attrs = bondStateAttrs s }
+
+let bridge
+    : Text -> BridgeState -> Assertion
+    = \(name : Text) ->
+      \(s : BridgeState) ->
+        { kind = "bridge", primaryKey = name, attrs = bridgeStateAttrs s }
+
+-- defaultGateway is a singleton: takes no Text argument; primaryKey is fixed
+-- to the kind name to satisfy non-empty validation. The emitter omits the
+-- (<primaryKey>) argument from the generated `describe` block.
+let defaultGateway
+    : DefaultGatewayState -> Assertion
+    = \(s : DefaultGatewayState) ->
+        { kind = "default_gateway"
+        , primaryKey = "default_gateway"
+        , attrs = defaultGatewayStateAttrs s
+        }
+
+let host
+    : Text -> HostState -> Assertion
+    = \(name : Text) ->
+      \(s : HostState) ->
+        { kind = "host", primaryKey = name, attrs = hostStateAttrs s }
+
+let ip6tables
+    : Text -> Ip6tablesState -> Assertion
+    = \(table : Text) ->
+      \(s : Ip6tablesState) ->
+        { kind = "ip6tables", primaryKey = table, attrs = ip6tablesStateAttrs s }
+
+let ipfilter
+    : Text -> IpfilterState -> Assertion
+    = \(label : Text) ->
+      \(s : IpfilterState) ->
+        { kind = "ipfilter", primaryKey = label, attrs = ipfilterStateAttrs s }
+
+let ipnat
+    : Text -> IpnatState -> Assertion
+    = \(label : Text) ->
+      \(s : IpnatState) ->
+        { kind = "ipnat", primaryKey = label, attrs = ipnatStateAttrs s }
+
+let iptables
+    : Text -> IptablesState -> Assertion
+    = \(table : Text) ->
+      \(s : IptablesState) ->
+        { kind = "iptables", primaryKey = table, attrs = iptablesStateAttrs s }
+
+-- routingTable is a singleton (no primary key); each HasEntry attaches one
+-- destination/gateway pair to the same describe block.
+let routingTable
+    : RoutingTableState -> Assertion
+    = \(s : RoutingTableState) ->
+        { kind = "routing_table"
+        , primaryKey = "routing_table"
+        , attrs = routingTableStateAttrs s
+        }
+
 in  { AttrValue         = AttrValue
     , Assertion         = Assertion
     , ServiceState      = ServiceState
@@ -217,6 +373,15 @@ in  { AttrValue         = AttrValue
     , MountState        = MountState
     , InterfaceState    = InterfaceState
     , KernelModuleState = KernelModuleState
+    , BondState           = BondState
+    , BridgeState         = BridgeState
+    , DefaultGatewayState = DefaultGatewayState
+    , HostState           = HostState
+    , Ip6tablesState      = Ip6tablesState
+    , IpfilterState       = IpfilterState
+    , IpnatState          = IpnatState
+    , IptablesState       = IptablesState
+    , RoutingTableState   = RoutingTableState
     , service           = service
     , package           = package
     , port              = port
@@ -228,5 +393,14 @@ in  { AttrValue         = AttrValue
     , mount             = mount
     , interface         = interface
     , kernelModule      = kernelModule
+    , bond              = bond
+    , bridge            = bridge
+    , defaultGateway    = defaultGateway
+    , host              = host
+    , ip6tables         = ip6tables
+    , ipfilter          = ipfilter
+    , ipnat             = ipnat
+    , iptables          = iptables
+    , routingTable      = routingTable
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -36,6 +36,8 @@ backendAllowedKinds = \case
   "serverspec" ->
     [ "service", "package", "port", "file", "command"
     , "user", "group", "process", "mount", "interface", "kernel-module"
+    , "bond", "bridge", "default_gateway", "host"
+    , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -12,6 +12,8 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty as NE
 import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
+import Data.Set (Set)
+import qualified Data.Set as Set
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Read as TR
@@ -68,7 +70,30 @@ serverspecSchema = Map.fromList
       ])
   , ("kernel-module", Map.fromList
       [ ("loaded", ATBool) ])
+  , ("bond", Map.fromList
+      [ ("exist", ATBool), ("interface", ATText) ])
+  , ("bridge", Map.fromList
+      [ ("exist", ATBool), ("interface", ATText) ])
+  , ("default_gateway", Map.fromList
+      [ ("ipaddress", ATText), ("interface", ATText) ])
+  , ("host", Map.fromList
+      [ ("resolvable", ATBool)
+      , ("reachable",  ATBool)
+      , ("ipaddress",  ATText)
+      ])
+  , ("ip6tables", Map.fromList [ ("rule", ATText) ])
+  , ("ipfilter",  Map.fromList [ ("rule", ATText) ])
+  , ("ipnat",     Map.fromList [ ("rule", ATText) ])
+  , ("iptables",  Map.fromList [ ("rule", ATText) ])
+  , ("routing_table", Map.empty)  -- wildcard kind: any AVText key allowed
   ]
+
+-- | Kinds whose @describe@ block takes no primary-key argument
+-- (e.g. @describe selinux do ... end@). The Dhall smart constructor for these
+-- kinds takes no @Text@ argument and stores the kind name as @primaryKey@ to
+-- satisfy layer-2 non-empty validation.
+singletonKinds :: Set Text
+singletonKinds = Set.fromList ["default_gateway", "routing_table"]
 
 tagOf :: AttrValue -> AttrTag
 tagOf = \case
@@ -98,14 +123,20 @@ validateAssertion a@(Assertion k pk attrs) = do
     Nothing -> Left ("unknown kind for serverspec: " <> k)
   when (Map.null attrs) $
     Left ("empty attrs for kind " <> k)
-  forM_ (Map.toAscList attrs) $ \(key, val) -> do
-    expected <- case Map.lookup key kindSchema of
-      Just t  -> Right t
-      Nothing -> Left ("unknown attrs key for kind " <> k <> ": " <> key)
-    let actual = tagOf val
-    unless (actual == expected) $
-      Left $ "wrong attr type for " <> k <> "." <> key
-          <> ": expected " <> showTag expected <> ", got " <> showTag actual
+  forM_ (Map.toAscList attrs) $ \(key, val) ->
+    if Map.null kindSchema
+      then
+        unless (tagOf val == ATText) $
+          Left $ "wildcard kind " <> k <> " requires Text values; got "
+              <> showTag (tagOf val) <> " for key " <> key
+      else do
+        expected <- case Map.lookup key kindSchema of
+          Just t  -> Right t
+          Nothing -> Left ("unknown attrs key for kind " <> k <> ": " <> key)
+        let actual = tagOf val
+        unless (actual == expected) $
+          Left $ "wrong attr type for " <> k <> "." <> key
+              <> ": expected " <> showTag expected <> ", got " <> showTag actual
   when (k == "port") $
     case TR.decimal pk :: Either String (Natural, Text) of
       Right (_, rest) | T.null rest -> Right ()
@@ -198,6 +229,28 @@ formatItLine "interface" "speed"          (AVNat n)  = "its(:speed) { should eq 
 formatItLine "interface" "ipv4_address"   (AVText a) = "it { should have_ipv4_address " <> rubyString a <> " }"
 -- kernel-module
 formatItLine "kernel-module" "loaded"     _          = "it { should be_loaded }"
+-- bond
+formatItLine "bond"      "exist"          _          = "it { should exist }"
+formatItLine "bond"      "interface"      (AVText i) = "it { should have_interface " <> rubyString i <> " }"
+-- bridge
+formatItLine "bridge"    "exist"          _          = "it { should exist }"
+formatItLine "bridge"    "interface"      (AVText i) = "it { should have_interface " <> rubyString i <> " }"
+-- default_gateway (singleton)
+formatItLine "default_gateway" "ipaddress" (AVText a) = "its(:ipaddress) { should eq " <> rubyString a <> " }"
+formatItLine "default_gateway" "interface" (AVText i) = "its(:interface) { should eq " <> rubyString i <> " }"
+-- host
+formatItLine "host"      "resolvable"     _          = "it { should be_resolvable }"
+formatItLine "host"      "reachable"      _          = "it { should be_reachable }"
+formatItLine "host"      "ipaddress"      (AVText a) = "its(:ipaddress) { should eq " <> rubyString a <> " }"
+-- iptables family
+formatItLine "ip6tables" "rule"           (AVText r) = "it { should have_rule " <> rubyString r <> " }"
+formatItLine "ipfilter"  "rule"           (AVText r) = "it { should have_rule " <> rubyString r <> " }"
+formatItLine "ipnat"     "rule"           (AVText r) = "it { should have_rule " <> rubyString r <> " }"
+formatItLine "iptables"  "rule"           (AVText r) = "it { should have_rule " <> rubyString r <> " }"
+-- routing_table (wildcard schema, singleton): mapKey = destination CIDR, mapValue = gateway
+formatItLine "routing_table" key          (AVText v) =
+  "it { should have_entry :destination => " <> rubyString key
+    <> ", :gateway => " <> rubyString v <> " }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 
@@ -210,12 +263,17 @@ kindToRubyResource = \case
   k               -> k
 
 -- | Render one merged 'Assertion' as a @describe ... do ... end@ block.
+-- Singleton kinds (see 'singletonKinds') drop the @(<primaryKey>)@ argument.
 formatGroup :: Assertion -> Either Text (Doc ann)
 formatGroup (Assertion k pk attrs) = do
-  hd <- primaryDoc k pk
   let resource = pretty (kindToRubyResource k)
-      header = "describe" <+> resource <> "(" <> hd <> ")" <+> "do"
-      body   = vsep [ formatItLine k key val | (key, val) <- Map.toAscList attrs ]
+  header <-
+    if Set.member k singletonKinds
+      then Right ("describe" <+> resource <+> "do")
+      else do
+        hd <- primaryDoc k pk
+        Right ("describe" <+> resource <> "(" <> hd <> ")" <+> "do")
+  let body = vsep [ formatItLine k key val | (key, val) <- Map.toAscList attrs ]
   pure $ vsep [header, indent 2 body, "end"]
 
 -- | Render a 'Job' as a @(filename, content)@ pair.

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -1,7 +1,22 @@
 require 'spec_helper'
 
+describe bond('bond0') do
+  it { should exist }
+  it { should have_interface 'eth0' }
+end
+
+describe bridge('br0') do
+  it { should exist }
+  it { should have_interface 'eth1' }
+end
+
 describe command('uname -a') do
   its(:exit_status) { should eq 0 }
+end
+
+describe default_gateway do
+  its(:interface) { should eq 'eth0' }
+  its(:ipaddress) { should eq '10.0.1.1' }
 end
 
 describe file('/etc/nginx/nginx.conf') do
@@ -22,10 +37,32 @@ describe group('nginx') do
   it { should have_gid 101 }
 end
 
+describe host('example.jp') do
+  its(:ipaddress) { should eq '192.0.2.1' }
+  it { should be_reachable }
+  it { should be_resolvable }
+end
+
 describe interface('eth0') do
   it { should exist }
   it { should have_ipv4_address '10.0.1.10' }
   its(:speed) { should eq 1000 }
+end
+
+describe ip6tables('filter') do
+  it { should have_rule '-P INPUT DROP' }
+end
+
+describe ipfilter('block') do
+  it { should have_rule 'block in all' }
+end
+
+describe ipnat('rdr') do
+  it { should have_rule 'rdr en0 0/0 port 80 -> 127.0.0.1 port 8080' }
+end
+
+describe iptables('filter') do
+  it { should have_rule '-P INPUT ACCEPT' }
 end
 
 describe kernel_module('br_netfilter') do
@@ -49,6 +86,10 @@ end
 describe process('nginx') do
   it { should be_running }
   its(:user) { should eq 'nginx' }
+end
+
+describe routing_table do
+  it { should have_entry :destination => '192.168.100.0/24', :gateway => '192.168.100.1' }
 end
 
 describe service('nginx') do

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -29,5 +29,24 @@ in  Plan.make Spec.targetBackend
           , Spec.interface "eth0" (Spec.InterfaceState.HasSpeed 1000)
           , Spec.interface "eth0" (Spec.InterfaceState.HasIpv4Address "10.0.1.10")
           , Spec.kernelModule "br_netfilter" Spec.KernelModuleState.Loaded
+          , Spec.bond "bond0" Spec.BondState.Exist
+          , Spec.bond "bond0" (Spec.BondState.HasInterface "eth0")
+          , Spec.bridge "br0" Spec.BridgeState.Exist
+          , Spec.bridge "br0" (Spec.BridgeState.HasInterface "eth1")
+          , Spec.defaultGateway (Spec.DefaultGatewayState.HasIpaddress "10.0.1.1")
+          , Spec.defaultGateway (Spec.DefaultGatewayState.HasInterface "eth0")
+          , Spec.host "example.jp" Spec.HostState.Resolvable
+          , Spec.host "example.jp" Spec.HostState.Reachable
+          , Spec.host "example.jp" (Spec.HostState.HasIpaddress "192.0.2.1")
+          , Spec.iptables "filter" (Spec.IptablesState.HasRule "-P INPUT ACCEPT")
+          , Spec.ip6tables "filter" (Spec.Ip6tablesState.HasRule "-P INPUT DROP")
+          , Spec.ipfilter "block" (Spec.IpfilterState.HasRule "block in all")
+          , Spec.ipnat "rdr" (Spec.IpnatState.HasRule "rdr en0 0/0 port 80 -> 127.0.0.1 port 8080")
+          , Spec.routingTable
+              ( Spec.RoutingTableState.HasEntry
+                  { destination = "192.168.100.0/24"
+                  , gateway     = "192.168.100.1"
+                  }
+              )
           ]
       ]

--- a/test/Property/EmitTest.hs
+++ b/test/Property/EmitTest.hs
@@ -3,7 +3,7 @@ module Property.EmitTest (tests) where
 import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
-import Test.QuickCheck (Gen, choose, elements, listOf, property, vectorOf)
+import Test.QuickCheck (Gen, choose, elements, listOf, oneof, property, vectorOf)
 import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty, counterexample, forAll, Property)
 
@@ -25,12 +25,28 @@ dummyNode = Node
   , tags     = []
   }
 
--- | Pick one schema-allowed @(kind, attrKey, AttrTag)@ triple.
+-- | Pick one schema-allowed @(kind, attrKey, AttrTag)@ triple. Wildcard kinds
+-- (empty attr schema) are excluded — they have no enumerable @(key, tag)@
+-- pairs and are exercised by 'genWildcardAssertion' instead.
 genKindKeyTag :: Gen (Text, Text, AttrTag)
 genKindKeyTag = do
-  (kind, attrSchema) <- elements (Map.toAscList serverspecSchema)
+  let enumerable =
+        [ (kind, attrs)
+        | (kind, attrs) <- Map.toAscList serverspecSchema
+        , not (Map.null attrs)
+        ]
+  (kind, attrSchema) <- elements enumerable
   (key, tag)         <- elements (Map.toAscList attrSchema)
   pure (kind, key, tag)
+
+-- | List of wildcard-schema kinds (empty attr map). For these, any AVText key
+-- is accepted by the validator.
+wildcardKinds :: [Text]
+wildcardKinds =
+  [ kind
+  | (kind, attrs) <- Map.toAscList serverspecSchema
+  , Map.null attrs
+  ]
 
 -- | Generate an 'AttrValue' matching the given 'AttrTag'.
 genValue :: AttrTag -> Gen AttrValue
@@ -49,12 +65,28 @@ genPrimaryKey :: Text -> Gen Text
 genPrimaryKey "port" = T.pack . show <$> choose (1 :: Int, 65535)
 genPrimaryKey _      = T.pack <$> shortAlphaNum
 
--- | Generate an Assertion that satisfies the Serverspec schema.
+-- | Generate an Assertion that satisfies the Serverspec schema. Mixes
+-- enumerable-schema kinds with wildcard-schema kinds so both code paths in
+-- the emitter are exercised.
 genValidAssertion :: Gen Assertion
-genValidAssertion = do
+genValidAssertion
+  | null wildcardKinds = genEnumerableAssertion
+  | otherwise          = oneof [genEnumerableAssertion, genWildcardAssertion]
+
+genEnumerableAssertion :: Gen Assertion
+genEnumerableAssertion = do
   (kind, key, tag) <- genKindKeyTag
   pk               <- genPrimaryKey kind
   val              <- genValue tag
+  pure (Assertion kind pk (Map.singleton key val))
+
+-- | Wildcard-kind assertion: dynamic attr key, AVText value.
+genWildcardAssertion :: Gen Assertion
+genWildcardAssertion = do
+  kind <- elements wildcardKinds
+  pk   <- genPrimaryKey kind
+  key  <- T.pack <$> shortAlphaNum
+  val  <- AVText . T.pack <$> shortAlphaNum
   pure (Assertion kind pk (Map.singleton key val))
 
 -- | Two assertions sharing @(kind, primaryKey, attrKey)@ but disagreeing on

--- a/test/Unit/ValidateTest.hs
+++ b/test/Unit/ValidateTest.hs
@@ -20,6 +20,8 @@ tests = testGroup "defense-in-depth"
   , testCase "layer 3: rejects conflicting attrs"   layer3ConflictingAttrs
   , testCase "layer 3: rejects empty attrs"         layer3EmptyAttrs
   , testCase "layer 3: rejects backend mismatch"    layer3BackendMismatch
+  , testCase "layer 3: rejects wildcard kind non-Text value" layer3WildcardWrongType
+  , testCase "layer 3: rejects routing_table conflicting gateway" layer3RoutingTableConflict
   ]
 
 assertLeftContains :: Text -> Either Text a -> IO ()
@@ -76,3 +78,22 @@ layer3BackendMismatch =
   -- exercise the dispatcher path which produces the equivalent guarantee.
   let ep = ExecutionPlan "" []
   in assertLeftContains "unknown backend" (emitFor ep)
+
+-- Wildcard kinds (e.g. routing_table) require AVText values for every attr key.
+layer3WildcardWrongType :: IO ()
+layer3WildcardWrongType =
+  let bad = Assertion "routing_table" "routing_table"
+              (Map.fromList [("10.0.0.0/8", AVNat 1)])
+      ep  = ExecutionPlan "serverspec" [Job (mkNode "h") [bad]]
+  in assertLeftContains "wildcard kind" (emitFor ep)
+
+-- Two routing_table entries sharing the same destination but disagreeing on
+-- the gateway must be rejected by the layer-3 conflict fail-safe.
+layer3RoutingTableConflict :: IO ()
+layer3RoutingTableConflict =
+  let a = Assertion "routing_table" "routing_table"
+            (Map.fromList [("10.0.0.0/8", AVText "10.0.0.1")])
+      b = Assertion "routing_table" "routing_table"
+            (Map.fromList [("10.0.0.0/8", AVText "10.0.0.2")])
+      ep = ExecutionPlan "serverspec" [Job (mkNode "h") [a, b]]
+  in assertLeftContains "conflicting attribute" (emitFor ep)


### PR DESCRIPTION
## Summary
- Extends `dhall/Serverspec.dhall` with smart constructors for the 9 network-related Serverspec resource types: `bond`, `bridge`, `default_gateway`, `host`, `ip6tables`, `ipfilter`, `ipnat`, `iptables`, `routing_table`.
- Introduces a `singletonKinds` set in the emitter so resources like `default_gateway` and `routing_table` emit `describe <resource> do ... end` (no primary-key argument).
- Introduces a wildcard-schema convention: an empty `serverspecSchema` entry means "any AVText attr key allowed", which `routing_table` uses to encode dynamic `:destination => X, :gateway => Y` pairs.
- Updates the layer-2 backend allowlist, expands the property test generator to cover wildcard kinds, adds two new unit-test cases (wildcard type check, routing_table conflict), extends the golden plan/expected, and adds 9 rows to the Resource catalogue table in the README.
- This is PR 1/5 of an effort to cover all 40 ServerSpec resource types. Compound matchers (e.g. `port` protocol, `host` `be_reachable.with(:port =>)`, x509 `validity_in_days` comparisons, registry property type tags) are out of scope here and need an `AttrValue` extension; they are tracked separately.

## Test plan
- [x] `cabal build` succeeds with the extended schema and Dhall prelude
- [x] `cabal test` — all 26 tests pass (golden, property, unit, roundtrip, SoT, synthetic)
- [x] Manual: `cabal run paninfraspec-gen -- --inventory test/Golden/inventory.dhall --plan test/Golden/plan.dhall --target serverspec --out /tmp/pis-out` produces output that matches `test/Golden/expected/`
- [ ] Optional manual: `bundle exec rake spec` against the generated `/tmp/pis-out` on a sandbox host (CI lacks a Serverspec runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)