### PR TITLE
Add 5 Linux system resources to Serverspec backend (PR 2/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,11 @@ matching `*State` union.
 | ipfilter | `ipfilter : Text -> IpfilterState -> Assertion` | `HasRule : Text` |
 | ipnat | `ipnat : Text -> IpnatState -> Assertion` | `HasRule : Text` |
 | Routing table (singleton) | `routingTable : RoutingTableState -> Assertion` | `HasEntry : { destination : Text, gateway : Text }` |
+| SELinux (singleton) | `selinux : SelinuxState -> Assertion` | `Enforcing`, `Permissive`, `Disabled` |
+| SELinux module | `selinuxModule : Text -> SelinuxModuleState -> Assertion` | `Enabled`, `Installed` |
+| Linux audit system (singleton) | `linuxAuditSystem : LinuxAuditSystemState -> Assertion` | `Running`, `Enabled` |
+| Linux kernel parameter | `linuxKernelParameter : Text -> LinuxKernelParameterState -> Assertion` | `HasValue : Text` |
+| Cgroup | `cgroup : Text -> CgroupState -> Assertion` | `HasParameter : { name : Text, value : Text }` |
 
 To express more than one state for the same resource (e.g. nginx must be both
 running and enabled), write two assertions with the same primary key — they

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -73,6 +73,16 @@ let IptablesState  = < HasRule : Text >
 let RoutingTableState =
       < HasEntry : { destination : Text, gateway : Text } >
 
+-- PR-2 Linux system / kernel resources --------------------------------------
+
+let SelinuxState = < Enforcing | Permissive | Disabled >
+let SelinuxModuleState = < Enabled | Installed >
+let LinuxAuditSystemState = < Running | Enabled >
+let LinuxKernelParameterState = < HasValue : Text >
+let CgroupState =
+      < HasParameter : { name : Text, value : Text } >
+
+
 
 -- Attribute encoders --------------------------------------------------------
 
@@ -229,6 +239,52 @@ let routingTableStateAttrs =
           }
           s
 
+let selinuxStateAttrs =
+      \(s : SelinuxState) ->
+        merge
+          { Enforcing  = toMap { enforcing  = AttrValue.AVBool True }
+          , Permissive = toMap { permissive = AttrValue.AVBool True }
+          , Disabled   = toMap { disabled   = AttrValue.AVBool True }
+          }
+          s
+
+let selinuxModuleStateAttrs =
+      \(s : SelinuxModuleState) ->
+        merge
+          { Enabled   = toMap { enabled   = AttrValue.AVBool True }
+          , Installed = toMap { installed = AttrValue.AVBool True }
+          }
+          s
+
+let linuxAuditSystemStateAttrs =
+      \(s : LinuxAuditSystemState) ->
+        merge
+          { Running = toMap { running = AttrValue.AVBool True }
+          , Enabled = toMap { enabled = AttrValue.AVBool True }
+          }
+          s
+
+let linuxKernelParameterStateAttrs =
+      \(s : LinuxKernelParameterState) ->
+        merge
+          { HasValue = \(v : Text) -> toMap { value = AttrValue.AVText v } }
+          s
+
+-- cgroup is a wildcard kind: HasParameter projects to a single attribute pair
+-- whose mapKey is the parameter name (e.g. "cpu.shares"). toMap cannot be
+-- used because the field name is value-dependent.
+let cgroupStateAttrs =
+      \(s : CgroupState) ->
+        merge
+          { HasParameter =
+              \(p : { name : Text, value : Text }) ->
+                [ { mapKey = p.name
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -360,6 +416,49 @@ let routingTable
         , attrs = routingTableStateAttrs s
         }
 
+-- selinux is a singleton; the three states are mutually exclusive in practice
+-- but the validator does not enforce mutual exclusion (a misuse manifests as
+-- a Ruby-level test failure).
+let selinux
+    : SelinuxState -> Assertion
+    = \(s : SelinuxState) ->
+        { kind = "selinux"
+        , primaryKey = "selinux"
+        , attrs = selinuxStateAttrs s
+        }
+
+let selinuxModule
+    : Text -> SelinuxModuleState -> Assertion
+    = \(name : Text) ->
+      \(s : SelinuxModuleState) ->
+        { kind = "selinux_module"
+        , primaryKey = name
+        , attrs = selinuxModuleStateAttrs s
+        }
+
+let linuxAuditSystem
+    : LinuxAuditSystemState -> Assertion
+    = \(s : LinuxAuditSystemState) ->
+        { kind = "linux_audit_system"
+        , primaryKey = "linux_audit_system"
+        , attrs = linuxAuditSystemStateAttrs s
+        }
+
+let linuxKernelParameter
+    : Text -> LinuxKernelParameterState -> Assertion
+    = \(name : Text) ->
+      \(s : LinuxKernelParameterState) ->
+        { kind = "linux_kernel_parameter"
+        , primaryKey = name
+        , attrs = linuxKernelParameterStateAttrs s
+        }
+
+let cgroup
+    : Text -> CgroupState -> Assertion
+    = \(name : Text) ->
+      \(s : CgroupState) ->
+        { kind = "cgroup", primaryKey = name, attrs = cgroupStateAttrs s }
+
 in  { AttrValue         = AttrValue
     , Assertion         = Assertion
     , ServiceState      = ServiceState
@@ -382,6 +481,11 @@ in  { AttrValue         = AttrValue
     , IpnatState          = IpnatState
     , IptablesState       = IptablesState
     , RoutingTableState   = RoutingTableState
+    , SelinuxState              = SelinuxState
+    , SelinuxModuleState        = SelinuxModuleState
+    , LinuxAuditSystemState     = LinuxAuditSystemState
+    , LinuxKernelParameterState = LinuxKernelParameterState
+    , CgroupState               = CgroupState
     , service           = service
     , package           = package
     , port              = port
@@ -402,5 +506,10 @@ in  { AttrValue         = AttrValue
     , ipnat             = ipnat
     , iptables          = iptables
     , routingTable      = routingTable
+    , selinux               = selinux
+    , selinuxModule         = selinuxModule
+    , linuxAuditSystem      = linuxAuditSystem
+    , linuxKernelParameter  = linuxKernelParameter
+    , cgroup                = cgroup
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -38,6 +38,8 @@ backendAllowedKinds = \case
     , "user", "group", "process", "mount", "interface", "kernel-module"
     , "bond", "bridge", "default_gateway", "host"
     , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
+    , "selinux", "selinux_module", "linux_audit_system"
+    , "linux_kernel_parameter", "cgroup"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -86,6 +86,22 @@ serverspecSchema = Map.fromList
   , ("ipnat",     Map.fromList [ ("rule", ATText) ])
   , ("iptables",  Map.fromList [ ("rule", ATText) ])
   , ("routing_table", Map.empty)  -- wildcard kind: any AVText key allowed
+  , ("selinux", Map.fromList
+      [ ("enforcing",  ATBool)
+      , ("permissive", ATBool)
+      , ("disabled",   ATBool)
+      ])
+  , ("selinux_module", Map.fromList
+      [ ("enabled",   ATBool)
+      , ("installed", ATBool)
+      ])
+  , ("linux_audit_system", Map.fromList
+      [ ("running", ATBool)
+      , ("enabled", ATBool)
+      ])
+  , ("linux_kernel_parameter", Map.fromList
+      [ ("value", ATText) ])
+  , ("cgroup", Map.empty)  -- wildcard kind: dynamic parameter names
   ]
 
 -- | Kinds whose @describe@ block takes no primary-key argument
@@ -93,7 +109,12 @@ serverspecSchema = Map.fromList
 -- kinds takes no @Text@ argument and stores the kind name as @primaryKey@ to
 -- satisfy layer-2 non-empty validation.
 singletonKinds :: Set Text
-singletonKinds = Set.fromList ["default_gateway", "routing_table"]
+singletonKinds = Set.fromList
+  [ "default_gateway"
+  , "routing_table"
+  , "selinux"
+  , "linux_audit_system"
+  ]
 
 tagOf :: AttrValue -> AttrTag
 tagOf = \case
@@ -251,6 +272,22 @@ formatItLine "iptables"  "rule"           (AVText r) = "it { should have_rule " 
 formatItLine "routing_table" key          (AVText v) =
   "it { should have_entry :destination => " <> rubyString key
     <> ", :gateway => " <> rubyString v <> " }"
+-- selinux (singleton): three mutually exclusive states
+formatItLine "selinux"   "enforcing"      _          = "it { should be_enforcing }"
+formatItLine "selinux"   "permissive"     _          = "it { should be_permissive }"
+formatItLine "selinux"   "disabled"       _          = "it { should be_disabled }"
+-- selinux_module
+formatItLine "selinux_module" "enabled"   _          = "it { should be_enabled }"
+formatItLine "selinux_module" "installed" _          = "it { should be_installed }"
+-- linux_audit_system (singleton)
+formatItLine "linux_audit_system" "running" _        = "it { should be_running }"
+formatItLine "linux_audit_system" "enabled" _        = "it { should be_enabled }"
+-- linux_kernel_parameter
+formatItLine "linux_kernel_parameter" "value" (AVText v) =
+  "its(:value) { should eq " <> rubyString v <> " }"
+-- cgroup (wildcard schema): each attr key is a cgroup parameter name
+formatItLine "cgroup"    key              (AVText v) =
+  "its(" <> rubyString key <> ") { should eq " <> rubyString v <> " }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -10,6 +10,10 @@ describe bridge('br0') do
   it { should have_interface 'eth1' }
 end
 
+describe cgroup('group1') do
+  its('cpu.shares') { should eq '256' }
+end
+
 describe command('uname -a') do
   its(:exit_status) { should eq 0 }
 end
@@ -69,6 +73,15 @@ describe kernel_module('br_netfilter') do
   it { should be_loaded }
 end
 
+describe linux_audit_system do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe linux_kernel_parameter('net.ipv4.ip_forward') do
+  its(:value) { should eq '1' }
+end
+
 describe mount('/data') do
   its(:device) { should eq '/dev/sda1' }
   its(:fstype) { should eq 'ext4' }
@@ -90,6 +103,15 @@ end
 
 describe routing_table do
   it { should have_entry :destination => '192.168.100.0/24', :gateway => '192.168.100.1' }
+end
+
+describe selinux do
+  it { should be_enforcing }
+end
+
+describe selinux_module('virt') do
+  it { should be_enabled }
+  it { should be_installed }
 end
 
 describe service('nginx') do

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -48,5 +48,16 @@ in  Plan.make Spec.targetBackend
                   , gateway     = "192.168.100.1"
                   }
               )
+          , Spec.selinux Spec.SelinuxState.Enforcing
+          , Spec.selinuxModule "virt" Spec.SelinuxModuleState.Installed
+          , Spec.selinuxModule "virt" Spec.SelinuxModuleState.Enabled
+          , Spec.linuxAuditSystem Spec.LinuxAuditSystemState.Running
+          , Spec.linuxAuditSystem Spec.LinuxAuditSystemState.Enabled
+          , Spec.linuxKernelParameter "net.ipv4.ip_forward"
+              (Spec.LinuxKernelParameterState.HasValue "1")
+          , Spec.cgroup "group1"
+              ( Spec.CgroupState.HasParameter
+                  { name = "cpu.shares", value = "256" }
+              )
           ]
       ]


### PR DESCRIPTION
## Summary
- Extends `dhall/Serverspec.dhall` with smart constructors for the 5 Linux-system Serverspec resource types: `selinux`, `selinux_module`, `linux_audit_system`, `linux_kernel_parameter`, `cgroup`.
- `selinux` and `linux_audit_system` are added as singleton kinds (no primary key); `cgroup` is added as a wildcard-schema kind whose attr keys are user-supplied parameter names (e.g. `cpu.shares`). Both reuse the foundations introduced in PR-1.
- Updates the layer-2 backend allowlist, extends the golden plan/expected, and adds 5 rows to the Resource catalogue table in the README.
- This is PR 2/5 of an effort to cover all 40 ServerSpec resource types. **Stacked on top of PR #4 (PR-1)**; merge target is `worktree-add-serverspec-resource` so the diff stays scoped to the PR-2 additions only.

## Scope deviation from the plan
- `linux_audit_system.HasRule : Text` is **omitted** in this PR. The current schema model can only express `Running` and `Enabled` (fixed Bool attr keys); supporting multiple rule entries per audit system would require a mixed schema combining fixed and dynamic attr keys (a "linux_audit_system" assertion can have both Bool flags and an unbounded number of rule strings). That is the same compound-matcher class that the deferred-matcher tracking issue covers, so it is left for that future PR.

## Test plan
- [x] `cabal build` succeeds with the extended schema and Dhall prelude
- [x] `cabal test` — all 26 tests pass (golden/property/unit/roundtrip/SoT/synthetic)
- [x] Manual: `cabal run paninfraspec-gen -- --inventory test/Golden/inventory.dhall --plan test/Golden/plan.dhall --target serverspec --out /tmp/pis-out` now emits `describe selinux do`, `describe linux_audit_system do`, `describe cgroup('group1') do its('cpu.shares') { should eq '256' } end`, `describe selinux_module('virt') do`, `describe linux_kernel_parameter('net.ipv4.ip_forward') do its(:value) { should eq '1' } end`
- [ ] Optional manual: `bundle exec rake spec` against the generated `/tmp/pis-out` on a sandbox host (CI lacks a Serverspec runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)