### PR TITLE
Add 3 container resources to Serverspec backend (PR 3/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,9 @@ matching `*State` union.
 | Linux audit system (singleton) | `linuxAuditSystem : LinuxAuditSystemState -> Assertion` | `Running`, `Enabled` |
 | Linux kernel parameter | `linuxKernelParameter : Text -> LinuxKernelParameterState -> Assertion` | `HasValue : Text` |
 | Cgroup | `cgroup : Text -> CgroupState -> Assertion` | `HasParameter : { name : Text, value : Text }` |
+| Docker container | `dockerContainer : Text -> DockerContainerState -> Assertion` | `Exist`, `Running`, `HasVolume : Text` |
+| Docker image | `dockerImage : Text -> DockerImageState -> Assertion` | `Exist` |
+| LXC | `lxc : Text -> LxcState -> Assertion` | `Exist`, `Running` |
 
 To express more than one state for the same resource (e.g. nginx must be both
 running and enabled), write two assertions with the same primary key — they

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -82,6 +82,16 @@ let LinuxKernelParameterState = < HasValue : Text >
 let CgroupState =
       < HasParameter : { name : Text, value : Text } >
 
+-- PR-3 container resources --------------------------------------------------
+
+let DockerContainerState =
+      < Exist
+      | Running
+      | HasVolume : Text
+      >
+let DockerImageState = < Exist >
+let LxcState = < Exist | Running >
+
 
 
 -- Attribute encoders --------------------------------------------------------
@@ -285,6 +295,26 @@ let cgroupStateAttrs =
           }
           s
 
+let dockerContainerStateAttrs =
+      \(s : DockerContainerState) ->
+        merge
+          { Exist     = toMap { exist   = AttrValue.AVBool True }
+          , Running   = toMap { running = AttrValue.AVBool True }
+          , HasVolume = \(v : Text) -> toMap { volume = AttrValue.AVText v }
+          }
+          s
+
+let dockerImageStateAttrs =
+      \(_ : DockerImageState) -> toMap { exist = AttrValue.AVBool True }
+
+let lxcStateAttrs =
+      \(s : LxcState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Running = toMap { running = AttrValue.AVBool True }
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -459,6 +489,30 @@ let cgroup
       \(s : CgroupState) ->
         { kind = "cgroup", primaryKey = name, attrs = cgroupStateAttrs s }
 
+let dockerContainer
+    : Text -> DockerContainerState -> Assertion
+    = \(name : Text) ->
+      \(s : DockerContainerState) ->
+        { kind = "docker_container"
+        , primaryKey = name
+        , attrs = dockerContainerStateAttrs s
+        }
+
+let dockerImage
+    : Text -> DockerImageState -> Assertion
+    = \(name : Text) ->
+      \(s : DockerImageState) ->
+        { kind = "docker_image"
+        , primaryKey = name
+        , attrs = dockerImageStateAttrs s
+        }
+
+let lxc
+    : Text -> LxcState -> Assertion
+    = \(name : Text) ->
+      \(s : LxcState) ->
+        { kind = "lxc", primaryKey = name, attrs = lxcStateAttrs s }
+
 in  { AttrValue         = AttrValue
     , Assertion         = Assertion
     , ServiceState      = ServiceState
@@ -486,6 +540,9 @@ in  { AttrValue         = AttrValue
     , LinuxAuditSystemState     = LinuxAuditSystemState
     , LinuxKernelParameterState = LinuxKernelParameterState
     , CgroupState               = CgroupState
+    , DockerContainerState      = DockerContainerState
+    , DockerImageState          = DockerImageState
+    , LxcState                  = LxcState
     , service           = service
     , package           = package
     , port              = port
@@ -511,5 +568,8 @@ in  { AttrValue         = AttrValue
     , linuxAuditSystem      = linuxAuditSystem
     , linuxKernelParameter  = linuxKernelParameter
     , cgroup                = cgroup
+    , dockerContainer       = dockerContainer
+    , dockerImage           = dockerImage
+    , lxc                   = lxc
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -40,6 +40,7 @@ backendAllowedKinds = \case
     , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
     , "selinux", "selinux_module", "linux_audit_system"
     , "linux_kernel_parameter", "cgroup"
+    , "docker_container", "docker_image", "lxc"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -102,6 +102,15 @@ serverspecSchema = Map.fromList
   , ("linux_kernel_parameter", Map.fromList
       [ ("value", ATText) ])
   , ("cgroup", Map.empty)  -- wildcard kind: dynamic parameter names
+  , ("docker_container", Map.fromList
+      [ ("exist",   ATBool)
+      , ("running", ATBool)
+      , ("volume",  ATText)
+      ])
+  , ("docker_image", Map.fromList
+      [ ("exist", ATBool) ])
+  , ("lxc", Map.fromList
+      [ ("exist", ATBool), ("running", ATBool) ])
   ]
 
 -- | Kinds whose @describe@ block takes no primary-key argument
@@ -288,6 +297,15 @@ formatItLine "linux_kernel_parameter" "value" (AVText v) =
 -- cgroup (wildcard schema): each attr key is a cgroup parameter name
 formatItLine "cgroup"    key              (AVText v) =
   "its(" <> rubyString key <> ") { should eq " <> rubyString v <> " }"
+-- docker_container
+formatItLine "docker_container" "exist"   _          = "it { should exist }"
+formatItLine "docker_container" "running" _          = "it { should be_running }"
+formatItLine "docker_container" "volume"  (AVText v) = "it { should have_volume " <> rubyString v <> " }"
+-- docker_image
+formatItLine "docker_image" "exist"       _          = "it { should exist }"
+-- lxc
+formatItLine "lxc"       "exist"          _          = "it { should exist }"
+formatItLine "lxc"       "running"        _          = "it { should be_running }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -23,6 +23,16 @@ describe default_gateway do
   its(:ipaddress) { should eq '10.0.1.1' }
 end
 
+describe docker_container('web') do
+  it { should exist }
+  it { should be_running }
+  it { should have_volume '/var/www' }
+end
+
+describe docker_image('nginx:latest') do
+  it { should exist }
+end
+
 describe file('/etc/nginx/nginx.conf') do
   it { should exist }
 end
@@ -80,6 +90,11 @@ end
 
 describe linux_kernel_parameter('net.ipv4.ip_forward') do
   its(:value) { should eq '1' }
+end
+
+describe lxc('container1') do
+  it { should exist }
+  it { should be_running }
 end
 
 describe mount('/data') do

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -59,5 +59,11 @@ in  Plan.make Spec.targetBackend
               ( Spec.CgroupState.HasParameter
                   { name = "cpu.shares", value = "256" }
               )
+          , Spec.dockerContainer "web" Spec.DockerContainerState.Exist
+          , Spec.dockerContainer "web" Spec.DockerContainerState.Running
+          , Spec.dockerContainer "web" (Spec.DockerContainerState.HasVolume "/var/www")
+          , Spec.dockerImage "nginx:latest" Spec.DockerImageState.Exist
+          , Spec.lxc "container1" Spec.LxcState.Exist
+          , Spec.lxc "container1" Spec.LxcState.Running
           ]
       ]


### PR DESCRIPTION
## Summary
- Extends `dhall/Serverspec.dhall` with smart constructors for the 3 container-related Serverspec resource types: `docker_container`, `docker_image`, `lxc`.
- All three use the conventional kind model (no singleton, no wildcard) and only fixed-key Bool/Text matchers, so this PR carries no foundation changes.
- Updates the layer-2 backend allowlist, extends the golden plan/expected, and adds 3 rows to the Resource catalogue table in the README.
- This is PR 3/5. **Stacked on top of PR #6 (PR-2)**; merge target is `add-serverspec-linux-resources` so the diff stays scoped to the PR-3 additions only.

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal test` — all 26 tests pass
- [x] Manual: generated output now includes `describe docker_container('web') do ... end`, `describe docker_image('nginx:latest') do ... end`, `describe lxc('container1') do ... end`
- [ ] Optional manual: `bundle exec rake spec` against the generated `/tmp/pis-out` on a sandbox host

🤖 Generated with [Claude Code](https://claude.com/claude-code)