### PR TITLE
Add 4 Windows resources to Serverspec backend (PR 4/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ matching `*State` union.
 | Docker container | `dockerContainer : Text -> DockerContainerState -> Assertion` | `Exist`, `Running`, `HasVolume : Text` |
 | Docker image | `dockerImage : Text -> DockerImageState -> Assertion` | `Exist` |
 | LXC | `lxc : Text -> LxcState -> Assertion` | `Exist`, `Running` |
+| IIS app pool | `iisAppPool : Text -> IisAppPoolState -> Assertion` | `Exist`, `HasDotnetVersion : Text` |
+| IIS website | `iisWebsite : Text -> IisWebsiteState -> Assertion` | `Exist`, `Enabled`, `Running`, `InAppPool : Text` |
+| Windows feature | `windowsFeature : Text -> WindowsFeatureState -> Assertion` | `Installed` |
+| Windows registry key | `windowsRegistryKey : Text -> WindowsRegistryKeyState -> Assertion` | `Exist`, `HasProperty : Text`, `HasValue : Text` |
 
 To express more than one state for the same resource (e.g. nginx must be both
 running and enabled), write two assertions with the same primary key — they

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -92,6 +92,25 @@ let DockerContainerState =
 let DockerImageState = < Exist >
 let LxcState = < Exist | Running >
 
+-- PR-4 Windows resources ----------------------------------------------------
+
+let IisAppPoolState =
+      < Exist
+      | HasDotnetVersion : Text
+      >
+let IisWebsiteState =
+      < Exist
+      | Enabled
+      | Running
+      | InAppPool : Text
+      >
+let WindowsFeatureState = < Installed >
+let WindowsRegistryKeyState =
+      < Exist
+      | HasProperty : Text
+      | HasValue    : Text
+      >
+
 
 
 -- Attribute encoders --------------------------------------------------------
@@ -315,6 +334,36 @@ let lxcStateAttrs =
           }
           s
 
+let iisAppPoolStateAttrs =
+      \(s : IisAppPoolState) ->
+        merge
+          { Exist            = toMap { exist = AttrValue.AVBool True }
+          , HasDotnetVersion = \(v : Text) -> toMap { dotnet_version = AttrValue.AVText v }
+          }
+          s
+
+let iisWebsiteStateAttrs =
+      \(s : IisWebsiteState) ->
+        merge
+          { Exist     = toMap { exist   = AttrValue.AVBool True }
+          , Enabled   = toMap { enabled = AttrValue.AVBool True }
+          , Running   = toMap { running = AttrValue.AVBool True }
+          , InAppPool = \(p : Text) -> toMap { in_app_pool = AttrValue.AVText p }
+          }
+          s
+
+let windowsFeatureStateAttrs =
+      \(_ : WindowsFeatureState) -> toMap { installed = AttrValue.AVBool True }
+
+let windowsRegistryKeyStateAttrs =
+      \(s : WindowsRegistryKeyState) ->
+        merge
+          { Exist       = toMap { exist = AttrValue.AVBool True }
+          , HasProperty = \(p : Text) -> toMap { property = AttrValue.AVText p }
+          , HasValue    = \(v : Text) -> toMap { value    = AttrValue.AVText v }
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -513,6 +562,42 @@ let lxc
       \(s : LxcState) ->
         { kind = "lxc", primaryKey = name, attrs = lxcStateAttrs s }
 
+let iisAppPool
+    : Text -> IisAppPoolState -> Assertion
+    = \(name : Text) ->
+      \(s : IisAppPoolState) ->
+        { kind = "iis_app_pool"
+        , primaryKey = name
+        , attrs = iisAppPoolStateAttrs s
+        }
+
+let iisWebsite
+    : Text -> IisWebsiteState -> Assertion
+    = \(name : Text) ->
+      \(s : IisWebsiteState) ->
+        { kind = "iis_website"
+        , primaryKey = name
+        , attrs = iisWebsiteStateAttrs s
+        }
+
+let windowsFeature
+    : Text -> WindowsFeatureState -> Assertion
+    = \(name : Text) ->
+      \(s : WindowsFeatureState) ->
+        { kind = "windows_feature"
+        , primaryKey = name
+        , attrs = windowsFeatureStateAttrs s
+        }
+
+let windowsRegistryKey
+    : Text -> WindowsRegistryKeyState -> Assertion
+    = \(path : Text) ->
+      \(s : WindowsRegistryKeyState) ->
+        { kind = "windows_registry_key"
+        , primaryKey = path
+        , attrs = windowsRegistryKeyStateAttrs s
+        }
+
 in  { AttrValue         = AttrValue
     , Assertion         = Assertion
     , ServiceState      = ServiceState
@@ -543,6 +628,10 @@ in  { AttrValue         = AttrValue
     , DockerContainerState      = DockerContainerState
     , DockerImageState          = DockerImageState
     , LxcState                  = LxcState
+    , IisAppPoolState           = IisAppPoolState
+    , IisWebsiteState           = IisWebsiteState
+    , WindowsFeatureState       = WindowsFeatureState
+    , WindowsRegistryKeyState   = WindowsRegistryKeyState
     , service           = service
     , package           = package
     , port              = port
@@ -571,5 +660,9 @@ in  { AttrValue         = AttrValue
     , dockerContainer       = dockerContainer
     , dockerImage           = dockerImage
     , lxc                   = lxc
+    , iisAppPool            = iisAppPool
+    , iisWebsite            = iisWebsite
+    , windowsFeature        = windowsFeature
+    , windowsRegistryKey    = windowsRegistryKey
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -41,6 +41,8 @@ backendAllowedKinds = \case
     , "selinux", "selinux_module", "linux_audit_system"
     , "linux_kernel_parameter", "cgroup"
     , "docker_container", "docker_image", "lxc"
+    , "iis_app_pool", "iis_website"
+    , "windows_feature", "windows_registry_key"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -111,6 +111,23 @@ serverspecSchema = Map.fromList
       [ ("exist", ATBool) ])
   , ("lxc", Map.fromList
       [ ("exist", ATBool), ("running", ATBool) ])
+  , ("iis_app_pool", Map.fromList
+      [ ("exist",          ATBool)
+      , ("dotnet_version", ATText)
+      ])
+  , ("iis_website", Map.fromList
+      [ ("exist",       ATBool)
+      , ("enabled",     ATBool)
+      , ("running",     ATBool)
+      , ("in_app_pool", ATText)
+      ])
+  , ("windows_feature", Map.fromList
+      [ ("installed", ATBool) ])
+  , ("windows_registry_key", Map.fromList
+      [ ("exist",    ATBool)
+      , ("property", ATText)
+      , ("value",    ATText)
+      ])
   ]
 
 -- | Kinds whose @describe@ block takes no primary-key argument
@@ -306,6 +323,20 @@ formatItLine "docker_image" "exist"       _          = "it { should exist }"
 -- lxc
 formatItLine "lxc"       "exist"          _          = "it { should exist }"
 formatItLine "lxc"       "running"        _          = "it { should be_running }"
+-- iis_app_pool
+formatItLine "iis_app_pool" "exist"          _          = "it { should exist }"
+formatItLine "iis_app_pool" "dotnet_version" (AVText v) = "it { should have_dotnet_version " <> rubyString v <> " }"
+-- iis_website
+formatItLine "iis_website" "exist"          _          = "it { should exist }"
+formatItLine "iis_website" "enabled"        _          = "it { should be_enabled }"
+formatItLine "iis_website" "running"        _          = "it { should be_running }"
+formatItLine "iis_website" "in_app_pool"    (AVText p) = "it { should be_in_app_pool " <> rubyString p <> " }"
+-- windows_feature
+formatItLine "windows_feature" "installed"  _          = "it { should be_installed }"
+-- windows_registry_key
+formatItLine "windows_registry_key" "exist"    _          = "it { should exist }"
+formatItLine "windows_registry_key" "property" (AVText p) = "it { should have_property " <> rubyString p <> " }"
+formatItLine "windows_registry_key" "value"    (AVText v) = "it { should have_value " <> rubyString v <> " }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -57,6 +57,17 @@ describe host('example.jp') do
   it { should be_resolvable }
 end
 
+describe iis_app_pool('DefaultAppPool') do
+  it { should have_dotnet_version 'v4.0' }
+  it { should exist }
+end
+
+describe iis_website('Default Web Site') do
+  it { should exist }
+  it { should be_in_app_pool 'DefaultAppPool' }
+  it { should be_running }
+end
+
 describe interface('eth0') do
   it { should exist }
   it { should have_ipv4_address '10.0.1.10' }
@@ -140,4 +151,14 @@ describe user('nginx') do
   it { should have_home_directory '/var/lib/nginx' }
   it { should have_login_shell '/usr/sbin/nologin' }
   it { should have_uid 101 }
+end
+
+describe windows_feature('Minesweeper') do
+  it { should be_installed }
+end
+
+describe windows_registry_key('HKLM\\SOFTWARE\\Test') do
+  it { should exist }
+  it { should have_property 'MyProperty' }
+  it { should have_value 'MyValue' }
 end

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -65,5 +65,14 @@ in  Plan.make Spec.targetBackend
           , Spec.dockerImage "nginx:latest" Spec.DockerImageState.Exist
           , Spec.lxc "container1" Spec.LxcState.Exist
           , Spec.lxc "container1" Spec.LxcState.Running
+          , Spec.iisAppPool "DefaultAppPool" Spec.IisAppPoolState.Exist
+          , Spec.iisAppPool "DefaultAppPool" (Spec.IisAppPoolState.HasDotnetVersion "v4.0")
+          , Spec.iisWebsite "Default Web Site" Spec.IisWebsiteState.Exist
+          , Spec.iisWebsite "Default Web Site" Spec.IisWebsiteState.Running
+          , Spec.iisWebsite "Default Web Site" (Spec.IisWebsiteState.InAppPool "DefaultAppPool")
+          , Spec.windowsFeature "Minesweeper" Spec.WindowsFeatureState.Installed
+          , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" Spec.WindowsRegistryKeyState.Exist
+          , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" (Spec.WindowsRegistryKeyState.HasProperty "MyProperty")
+          , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" (Spec.WindowsRegistryKeyState.HasValue "MyValue")
           ]
       ]


### PR DESCRIPTION
## Summary
- Extends `dhall/Serverspec.dhall` with smart constructors for the 4 Windows-related Serverspec resource types: `iis_app_pool`, `iis_website`, `windows_feature`, `windows_registry_key`.
- All four use the conventional kind model (no singleton, no wildcard) and only fixed-key Bool/Text matchers.
- Updates the layer-2 backend allowlist, extends the golden plan/expected, and adds 4 rows to the Resource catalogue table in the README.
- This is PR 4/5. **Stacked on top of PR #7 (PR-3)**; merge target is `add-serverspec-container-resources`.

## Scope
Compound matchers stay deferred for the AttrValue extension PR: `windows_feature.by('dism')`, `windows_registry_key.have_property "Name", :type_dword`, and `have_property_value` with the type-tag triple all require Ruby symbols / structured arguments that the current `AttrValue = Text | Natural | Bool` model cannot express.

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal test` — all 26 tests pass
- [x] Manual: generated output now includes `describe iis_app_pool('DefaultAppPool') do ... end`, `describe iis_website('Default Web Site') do ... end`, `describe windows_feature('Minesweeper') do ... end`, `describe windows_registry_key('HKLM\\SOFTWARE\\Test') do ... end` (backslashes correctly escaped for Ruby single-quoted strings)
- [ ] Optional manual: `bundle exec rake spec` against the generated `/tmp/pis-out` on a sandbox host

🤖 Generated with [Claude Code](https://claude.com/claude-code)