### PR TITLE
Add 9 middleware/misc resources to Serverspec backend (PR 5/5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,15 @@ matching `*State` union.
 | IIS website | `iisWebsite : Text -> IisWebsiteState -> Assertion` | `Exist`, `Enabled`, `Running`, `InAppPool : Text` |
 | Windows feature | `windowsFeature : Text -> WindowsFeatureState -> Assertion` | `Installed` |
 | Windows registry key | `windowsRegistryKey : Text -> WindowsRegistryKeyState -> Assertion` | `Exist`, `HasProperty : Text`, `HasValue : Text` |
+| Cron (singleton) | `cron : CronState -> Assertion` | `HasEntry : Text` |
+| Mail alias | `mailAlias : Text -> MailAliasState -> Assertion` | `AliasedTo : Text` |
+| MySQL config | `mysqlConfig : Text -> MysqlConfigState -> Assertion` | `HasValue : Text` |
+| PHP config | `phpConfig : Text -> PhpConfigState -> Assertion` | `HasValue : Text` |
+| PPA | `ppa : Text -> PpaState -> Assertion` | `Exist`, `Enabled` |
+| Yumrepo | `yumrepo : Text -> YumrepoState -> Assertion` | `Exist`, `Enabled` |
+| X.509 certificate | `x509Certificate : Text -> X509CertificateState -> Assertion` | `Certificate`, `Valid` |
+| X.509 private key | `x509PrivateKey : Text -> X509PrivateKeyState -> Assertion` | `Valid`, `Encrypted`, `HasMatchingCertificate : Text` |
+| ZFS | `zfs : Text -> ZfsState -> Assertion` | `HasProperty : { name : Text, value : Text }` |
 
 To express more than one state for the same resource (e.g. nginx must be both
 running and enabled), write two assertions with the same primary key — they

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -111,6 +111,22 @@ let WindowsRegistryKeyState =
       | HasValue    : Text
       >
 
+-- PR-5 middleware & misc resources ------------------------------------------
+
+let CronState = < HasEntry : Text >
+let MailAliasState = < AliasedTo : Text >
+let MysqlConfigState = < HasValue : Text >
+let PhpConfigState = < HasValue : Text >
+let PpaState = < Exist | Enabled >
+let YumrepoState = < Exist | Enabled >
+let X509CertificateState = < Certificate | Valid >
+let X509PrivateKeyState =
+      < Valid
+      | Encrypted
+      | HasMatchingCertificate : Text
+      >
+let ZfsState = < HasProperty : { name : Text, value : Text } >
+
 
 
 -- Attribute encoders --------------------------------------------------------
@@ -364,6 +380,83 @@ let windowsRegistryKeyStateAttrs =
           }
           s
 
+-- cron is a wildcard + singleton kind: each HasEntry stores the entry string
+-- itself as the dynamic mapKey so multiple entries don't conflict on a single
+-- shared attr key. The mapValue is a placeholder; only the key is meaningful.
+let cronStateAttrs =
+      \(s : CronState) ->
+        merge
+          { HasEntry =
+              \(e : Text) ->
+                [ { mapKey = e, mapValue = AttrValue.AVText "" } ]
+          }
+          s
+
+let mailAliasStateAttrs =
+      \(s : MailAliasState) ->
+        merge
+          { AliasedTo = \(t : Text) -> toMap { aliased_to = AttrValue.AVText t } }
+          s
+
+let mysqlConfigStateAttrs =
+      \(s : MysqlConfigState) ->
+        merge
+          { HasValue = \(v : Text) -> toMap { value = AttrValue.AVText v } }
+          s
+
+let phpConfigStateAttrs =
+      \(s : PhpConfigState) ->
+        merge
+          { HasValue = \(v : Text) -> toMap { value = AttrValue.AVText v } }
+          s
+
+let ppaStateAttrs =
+      \(s : PpaState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Enabled = toMap { enabled = AttrValue.AVBool True }
+          }
+          s
+
+let yumrepoStateAttrs =
+      \(s : YumrepoState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Enabled = toMap { enabled = AttrValue.AVBool True }
+          }
+          s
+
+let x509CertificateStateAttrs =
+      \(s : X509CertificateState) ->
+        merge
+          { Certificate = toMap { certificate = AttrValue.AVBool True }
+          , Valid       = toMap { valid       = AttrValue.AVBool True }
+          }
+          s
+
+let x509PrivateKeyStateAttrs =
+      \(s : X509PrivateKeyState) ->
+        merge
+          { Valid                  = toMap { valid     = AttrValue.AVBool True }
+          , Encrypted              = toMap { encrypted = AttrValue.AVBool True }
+          , HasMatchingCertificate = \(p : Text) -> toMap { matching_certificate = AttrValue.AVText p }
+          }
+          s
+
+-- zfs is a wildcard kind: each HasProperty pair becomes a (name, value)
+-- attribute whose name is the dynamic mapKey.
+let zfsStateAttrs =
+      \(s : ZfsState) ->
+        merge
+          { HasProperty =
+              \(p : { name : Text, value : Text }) ->
+                [ { mapKey = p.name
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -598,6 +691,79 @@ let windowsRegistryKey
         , attrs = windowsRegistryKeyStateAttrs s
         }
 
+-- cron is a singleton + wildcard: takes no Text argument, every HasEntry
+-- stores the entry string itself as the dynamic mapKey.
+let cron
+    : CronState -> Assertion
+    = \(s : CronState) ->
+        { kind = "cron"
+        , primaryKey = "cron"
+        , attrs = cronStateAttrs s
+        }
+
+let mailAlias
+    : Text -> MailAliasState -> Assertion
+    = \(name : Text) ->
+      \(s : MailAliasState) ->
+        { kind = "mail_alias"
+        , primaryKey = name
+        , attrs = mailAliasStateAttrs s
+        }
+
+let mysqlConfig
+    : Text -> MysqlConfigState -> Assertion
+    = \(name : Text) ->
+      \(s : MysqlConfigState) ->
+        { kind = "mysql_config"
+        , primaryKey = name
+        , attrs = mysqlConfigStateAttrs s
+        }
+
+let phpConfig
+    : Text -> PhpConfigState -> Assertion
+    = \(name : Text) ->
+      \(s : PhpConfigState) ->
+        { kind = "php_config"
+        , primaryKey = name
+        , attrs = phpConfigStateAttrs s
+        }
+
+let ppa
+    : Text -> PpaState -> Assertion
+    = \(name : Text) ->
+      \(s : PpaState) ->
+        { kind = "ppa", primaryKey = name, attrs = ppaStateAttrs s }
+
+let yumrepo
+    : Text -> YumrepoState -> Assertion
+    = \(name : Text) ->
+      \(s : YumrepoState) ->
+        { kind = "yumrepo", primaryKey = name, attrs = yumrepoStateAttrs s }
+
+let x509Certificate
+    : Text -> X509CertificateState -> Assertion
+    = \(path : Text) ->
+      \(s : X509CertificateState) ->
+        { kind = "x509_certificate"
+        , primaryKey = path
+        , attrs = x509CertificateStateAttrs s
+        }
+
+let x509PrivateKey
+    : Text -> X509PrivateKeyState -> Assertion
+    = \(path : Text) ->
+      \(s : X509PrivateKeyState) ->
+        { kind = "x509_private_key"
+        , primaryKey = path
+        , attrs = x509PrivateKeyStateAttrs s
+        }
+
+let zfs
+    : Text -> ZfsState -> Assertion
+    = \(name : Text) ->
+      \(s : ZfsState) ->
+        { kind = "zfs", primaryKey = name, attrs = zfsStateAttrs s }
+
 in  { AttrValue         = AttrValue
     , Assertion         = Assertion
     , ServiceState      = ServiceState
@@ -632,6 +798,15 @@ in  { AttrValue         = AttrValue
     , IisWebsiteState           = IisWebsiteState
     , WindowsFeatureState       = WindowsFeatureState
     , WindowsRegistryKeyState   = WindowsRegistryKeyState
+    , CronState                 = CronState
+    , MailAliasState            = MailAliasState
+    , MysqlConfigState          = MysqlConfigState
+    , PhpConfigState            = PhpConfigState
+    , PpaState                  = PpaState
+    , YumrepoState              = YumrepoState
+    , X509CertificateState      = X509CertificateState
+    , X509PrivateKeyState       = X509PrivateKeyState
+    , ZfsState                  = ZfsState
     , service           = service
     , package           = package
     , port              = port
@@ -664,5 +839,14 @@ in  { AttrValue         = AttrValue
     , iisWebsite            = iisWebsite
     , windowsFeature        = windowsFeature
     , windowsRegistryKey    = windowsRegistryKey
+    , cron                  = cron
+    , mailAlias             = mailAlias
+    , mysqlConfig           = mysqlConfig
+    , phpConfig             = phpConfig
+    , ppa                   = ppa
+    , yumrepo               = yumrepo
+    , x509Certificate       = x509Certificate
+    , x509PrivateKey        = x509PrivateKey
+    , zfs                   = zfs
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -43,6 +43,9 @@ backendAllowedKinds = \case
     , "docker_container", "docker_image", "lxc"
     , "iis_app_pool", "iis_website"
     , "windows_feature", "windows_registry_key"
+    , "cron", "mail_alias", "mysql_config", "php_config"
+    , "ppa", "yumrepo"
+    , "x509_certificate", "x509_private_key", "zfs"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -128,6 +128,25 @@ serverspecSchema = Map.fromList
       , ("property", ATText)
       , ("value",    ATText)
       ])
+  , ("cron", Map.empty)  -- wildcard + singleton: each attr key is an entry string
+  , ("mail_alias", Map.fromList
+      [ ("aliased_to", ATText) ])
+  , ("mysql_config", Map.fromList
+      [ ("value", ATText) ])
+  , ("php_config", Map.fromList
+      [ ("value", ATText) ])
+  , ("ppa", Map.fromList
+      [ ("exist", ATBool), ("enabled", ATBool) ])
+  , ("yumrepo", Map.fromList
+      [ ("exist", ATBool), ("enabled", ATBool) ])
+  , ("x509_certificate", Map.fromList
+      [ ("certificate", ATBool), ("valid", ATBool) ])
+  , ("x509_private_key", Map.fromList
+      [ ("valid",                ATBool)
+      , ("encrypted",            ATBool)
+      , ("matching_certificate", ATText)
+      ])
+  , ("zfs", Map.empty)  -- wildcard: each attr key is a zfs property name
   ]
 
 -- | Kinds whose @describe@ block takes no primary-key argument
@@ -140,6 +159,7 @@ singletonKinds = Set.fromList
   , "routing_table"
   , "selinux"
   , "linux_audit_system"
+  , "cron"
   ]
 
 tagOf :: AttrValue -> AttrTag
@@ -337,6 +357,32 @@ formatItLine "windows_feature" "installed"  _          = "it { should be_install
 formatItLine "windows_registry_key" "exist"    _          = "it { should exist }"
 formatItLine "windows_registry_key" "property" (AVText p) = "it { should have_property " <> rubyString p <> " }"
 formatItLine "windows_registry_key" "value"    (AVText v) = "it { should have_value " <> rubyString v <> " }"
+-- cron (wildcard + singleton): each attr key is the entry string itself
+formatItLine "cron"      key              _          =
+  "it { should have_entry " <> rubyString key <> " }"
+-- mail_alias
+formatItLine "mail_alias" "aliased_to"    (AVText v) = "it { should be_aliased_to " <> rubyString v <> " }"
+-- mysql_config
+formatItLine "mysql_config" "value"       (AVText v) = "its(:value) { should eq " <> rubyString v <> " }"
+-- php_config
+formatItLine "php_config" "value"         (AVText v) = "its(:value) { should eq " <> rubyString v <> " }"
+-- ppa
+formatItLine "ppa"       "exist"          _          = "it { should exist }"
+formatItLine "ppa"       "enabled"        _          = "it { should be_enabled }"
+-- yumrepo
+formatItLine "yumrepo"   "exist"          _          = "it { should exist }"
+formatItLine "yumrepo"   "enabled"        _          = "it { should be_enabled }"
+-- x509_certificate
+formatItLine "x509_certificate" "certificate" _      = "it { should be_certificate }"
+formatItLine "x509_certificate" "valid"       _      = "it { should be_valid }"
+-- x509_private_key
+formatItLine "x509_private_key" "valid"               _          = "it { should be_valid }"
+formatItLine "x509_private_key" "encrypted"           _          = "it { should be_encrypted }"
+formatItLine "x509_private_key" "matching_certificate" (AVText p) =
+  "it { should have_matching_certificate " <> rubyString p <> " }"
+-- zfs (wildcard schema): each attr key is a zfs property name
+formatItLine "zfs"       key              (AVText v) =
+  "it { should have_property " <> rubyString key <> " => " <> rubyString v <> " }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -18,6 +18,11 @@ describe command('uname -a') do
   its(:exit_status) { should eq 0 }
 end
 
+describe cron do
+  it { should have_entry '0 4 * * * /usr/sbin/run_daily_jobs' }
+  it { should have_entry '0 6 * * * /usr/sbin/run_morning_jobs' }
+end
+
 describe default_gateway do
   its(:interface) { should eq 'eth0' }
   its(:ipaddress) { should eq '10.0.1.1' }
@@ -108,18 +113,35 @@ describe lxc('container1') do
   it { should be_running }
 end
 
+describe mail_alias('info') do
+  it { should be_aliased_to 'admin' }
+end
+
 describe mount('/data') do
   its(:device) { should eq '/dev/sda1' }
   its(:fstype) { should eq 'ext4' }
   it { should be_mounted }
 end
 
+describe mysql_config('max_connections') do
+  its(:value) { should eq '256' }
+end
+
 describe package('nginx') do
   it { should be_installed }
 end
 
+describe php_config('default_charset') do
+  its(:value) { should eq 'UTF-8' }
+end
+
 describe port(80) do
   it { should be_listening }
+end
+
+describe ppa('ppa:nginx/stable') do
+  it { should be_enabled }
+  it { should exist }
 end
 
 describe process('nginx') do
@@ -161,4 +183,24 @@ describe windows_registry_key('HKLM\\SOFTWARE\\Test') do
   it { should exist }
   it { should have_property 'MyProperty' }
   it { should have_value 'MyValue' }
+end
+
+describe x509_certificate('/etc/ssl/cert.pem') do
+  it { should be_certificate }
+  it { should be_valid }
+end
+
+describe x509_private_key('/etc/ssl/key.pem') do
+  it { should be_encrypted }
+  it { should have_matching_certificate '/etc/ssl/cert.pem' }
+  it { should be_valid }
+end
+
+describe yumrepo('epel') do
+  it { should be_enabled }
+  it { should exist }
+end
+
+describe zfs('rpool/var') do
+  it { should have_property 'mountpoint' => '/var' }
 end

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -74,5 +74,24 @@ in  Plan.make Spec.targetBackend
           , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" Spec.WindowsRegistryKeyState.Exist
           , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" (Spec.WindowsRegistryKeyState.HasProperty "MyProperty")
           , Spec.windowsRegistryKey "HKLM\\SOFTWARE\\Test" (Spec.WindowsRegistryKeyState.HasValue "MyValue")
+          , Spec.cron (Spec.CronState.HasEntry "0 4 * * * /usr/sbin/run_daily_jobs")
+          , Spec.cron (Spec.CronState.HasEntry "0 6 * * * /usr/sbin/run_morning_jobs")
+          , Spec.mailAlias "info" (Spec.MailAliasState.AliasedTo "admin")
+          , Spec.mysqlConfig "max_connections" (Spec.MysqlConfigState.HasValue "256")
+          , Spec.phpConfig "default_charset" (Spec.PhpConfigState.HasValue "UTF-8")
+          , Spec.ppa "ppa:nginx/stable" Spec.PpaState.Exist
+          , Spec.ppa "ppa:nginx/stable" Spec.PpaState.Enabled
+          , Spec.yumrepo "epel" Spec.YumrepoState.Exist
+          , Spec.yumrepo "epel" Spec.YumrepoState.Enabled
+          , Spec.x509Certificate "/etc/ssl/cert.pem" Spec.X509CertificateState.Certificate
+          , Spec.x509Certificate "/etc/ssl/cert.pem" Spec.X509CertificateState.Valid
+          , Spec.x509PrivateKey "/etc/ssl/key.pem" Spec.X509PrivateKeyState.Valid
+          , Spec.x509PrivateKey "/etc/ssl/key.pem" Spec.X509PrivateKeyState.Encrypted
+          , Spec.x509PrivateKey "/etc/ssl/key.pem"
+              (Spec.X509PrivateKeyState.HasMatchingCertificate "/etc/ssl/cert.pem")
+          , Spec.zfs "rpool/var"
+              ( Spec.ZfsState.HasProperty
+                  { name = "mountpoint", value = "/var" }
+              )
           ]
       ]


### PR DESCRIPTION
## Summary
- Extends `dhall/Serverspec.dhall` with smart constructors for the remaining 9 Serverspec resource types: `cron`, `mail_alias`, `mysql_config`, `php_config`, `ppa`, `yumrepo`, `x509_certificate`, `x509_private_key`, `zfs`.
- `cron` is added as a singleton + wildcard kind: each `HasEntry` value becomes its own dynamic attr key so multiple entries don't merge-conflict on a shared key. `zfs` is added as a wildcard kind whose attr keys are zfs property names. The other seven use the conventional fixed-key model.
- Updates the layer-2 backend allowlist, extends the golden plan/expected, and adds 9 rows to the Resource catalogue table in the README.
- This is **PR 5/5**, the final PR in the series covering all 40 resource types from https://serverspec.org/resource_types.html with their primary matchers. **Stacked on top of PR #8 (PR-4)**; merge target is `add-serverspec-windows-resources`.

## Scope deviations from the plan
- `zfs.Exist` is **omitted**. `zfs` is a wildcard kind and the current model cannot mix fixed Bool attrs (`exist`) with dynamic Text attrs (`have_property`). Same shape of constraint as `linux_audit_system.HasRule` from PR-2.
- Compound matchers stay deferred to the AttrValue extension PR: `x509_certificate.validity_in_days` with comparison operators, `selinux_module.with_version`, `windows_feature.by()`, `port` protocol via `with()`, `host` `be_reachable.with(:port => 22)`, and registry property type tags.

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal test` — all 26 tests pass
- [x] Manual: generated output now includes `describe cron do it { should have_entry '0 4 * * * ...' } end`, `describe mail_alias('info') do it { should be_aliased_to 'admin' } end`, `describe mysql_config('max_connections') do its(:value) { should eq '256' } end`, `describe ppa('...') do ... end`, `describe yumrepo('epel') do ... end`, `describe x509_certificate('/etc/ssl/cert.pem') do ... end`, `describe x509_private_key('/etc/ssl/key.pem') do ... end`, `describe zfs('rpool/var') do it { should have_property 'mountpoint' => '/var' } end`
- [ ] Optional manual: `bundle exec rake spec` against the generated `/tmp/pis-out` on a sandbox host

## Series complete
With this PR merged, `dhall/Serverspec.dhall` exposes smart constructors for **all 40** resource types from the official Serverspec resource list. Each resource's primary matchers are covered. Compound/parametric matchers requiring richer than `Text | Natural | Bool` AttrValues remain in a tracked future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)