### PR TITLE
Complete serverspec.org coverage with 12 remaining resources

### DIFF
--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -3,13 +3,14 @@
 -- Smart constructors enforce Resource × State pairing at the input boundary
 -- (Defense-in-depth layer 1). See specification.md §3.2 / §5.4.
 
-let CompareOp = < Lt | Le | Gt | Ge | Eq >
+let CompareOp = < Lt | Le | Gt | Ge | Eq | Match >
 
 let AttrLeaf =
       < ALText   : Text
       | ALNat    : Natural
       | ALBool   : Bool
       | ALSymbol : Text
+      | ALRegex  : Text
       >
 
 let AttrValue =
@@ -154,6 +155,75 @@ let X509CertificateState =
 let WindowsRegistryKeyState =
       < HasProperty      : { name : Text, propertyType : Text }
       | HasPropertyValue : { name : Text, propertyType : Text, value : Natural }
+      >
+
+-- Phase 3 (serverspec.org coverage completion): 12 remaining kinds -----------
+
+let LxcState  = < Exist | Running >
+
+let MailAliasState = < AliasedTo : Text >
+
+let PpaState     = < Exist | Enabled >
+let YumrepoState = < Exist | Enabled >
+
+let IisAppPoolState =
+      < Exist
+      | HasDotnetVersion : Text
+      >
+
+let IisWebsiteState =
+      < Exist
+      | Enabled
+      | Running
+      | InAppPool       : Text
+      | HasPhysicalPath : Text
+      >
+
+let MysqlConfigState =
+      < EqText  : Text
+      | EqNat   : Natural
+      | Compare : { op : CompareOp, value : Natural }
+      >
+
+let PhpConfigState =
+      < EqText  : Text
+      | EqNat   : Natural
+      | Compare : { op : CompareOp, value : Natural }
+      | Match   : Text
+      >
+
+let X509PrivateKeyState =
+      < Encrypted
+      | NotEncrypted
+      | Valid
+      | HasMatchingCertificate : Text
+      >
+
+let ZfsState =
+      < Exist
+      | HasProperty : List { mapKey : Text, mapValue : Text }
+      >
+
+let DockerContainerState =
+      < Exist
+      | Running
+      | HasVolume       : { containerPath : Text, hostPath : Text }
+      | InspectEqText   : { keyPath : Text, value : Text }
+      | InspectEqNat    : { keyPath : Text, value : Natural }
+      | InspectEqBool   : { keyPath : Text, value : Bool }
+      | InspectEqSymbol : { keyPath : Text, value : Text }
+      | InspectInclude  : { keyPath : Text, value : Text }
+      | InspectionNotInclude : { key : Text, value : Text }
+      >
+
+let DockerImageState =
+      < Exist
+      | InspectEqText   : { keyPath : Text, value : Text }
+      | InspectEqNat    : { keyPath : Text, value : Natural }
+      | InspectEqBool   : { keyPath : Text, value : Bool }
+      | InspectEqSymbol : { keyPath : Text, value : Text }
+      | InspectInclude  : { keyPath : Text, value : Text }
+      | InspectionNotInclude : { key : Text, value : Text }
       >
 
 -- Attribute encoders --------------------------------------------------------
@@ -587,6 +657,248 @@ let windowsRegistryKeyStateAttrs =
           }
           s
 
+-- Phase 3 attribute encoders -------------------------------------------------
+
+let lxcStateAttrs =
+      \(s : LxcState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Running = toMap { running = AttrValue.AVBool True }
+          }
+          s
+
+let mailAliasStateAttrs =
+      \(s : MailAliasState) ->
+        merge
+          { AliasedTo =
+              \(r : Text) -> toMap { aliased_to = AttrValue.AVText r }
+          }
+          s
+
+let ppaStateAttrs =
+      \(s : PpaState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Enabled = toMap { enabled = AttrValue.AVBool True }
+          }
+          s
+
+let yumrepoStateAttrs =
+      \(s : YumrepoState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Enabled = toMap { enabled = AttrValue.AVBool True }
+          }
+          s
+
+let iisAppPoolStateAttrs =
+      \(s : IisAppPoolState) ->
+        merge
+          { Exist            = toMap { exist = AttrValue.AVBool True }
+          , HasDotnetVersion =
+              \(v : Text) -> toMap { dotnet_version = AttrValue.AVText v }
+          }
+          s
+
+let iisWebsiteStateAttrs =
+      \(s : IisWebsiteState) ->
+        merge
+          { Exist           = toMap { exist   = AttrValue.AVBool True }
+          , Enabled         = toMap { enabled = AttrValue.AVBool True }
+          , Running         = toMap { running = AttrValue.AVBool True }
+          , InAppPool       =
+              \(p : Text) -> toMap { in_app_pool   = AttrValue.AVText p }
+          , HasPhysicalPath =
+              \(p : Text) -> toMap { physical_path = AttrValue.AVText p }
+          }
+          s
+
+let mysqlConfigStateAttrs =
+      \(s : MysqlConfigState) ->
+        merge
+          { EqText =
+              \(t : Text) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = CompareOp.Eq, value = AttrLeaf.ALText t }
+                  }
+          , EqNat =
+              \(n : Natural) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = CompareOp.Eq, value = AttrLeaf.ALNat n }
+                  }
+          , Compare =
+              \(c : { op : CompareOp, value : Natural }) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = c.op, value = AttrLeaf.ALNat c.value }
+                  }
+          }
+          s
+
+let phpConfigStateAttrs =
+      \(s : PhpConfigState) ->
+        merge
+          { EqText =
+              \(t : Text) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = CompareOp.Eq, value = AttrLeaf.ALText t }
+                  }
+          , EqNat =
+              \(n : Natural) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = CompareOp.Eq, value = AttrLeaf.ALNat n }
+                  }
+          , Compare =
+              \(c : { op : CompareOp, value : Natural }) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = c.op, value = AttrLeaf.ALNat c.value }
+                  }
+          , Match =
+              \(p : Text) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = CompareOp.Match, value = AttrLeaf.ALRegex p }
+                  }
+          }
+          s
+
+let x509PrivateKeyStateAttrs =
+      \(s : X509PrivateKeyState) ->
+        merge
+          { Encrypted    = toMap { encrypted     = AttrValue.AVBool True }
+          , NotEncrypted = toMap { not_encrypted = AttrValue.AVBool True }
+          , Valid        = toMap { valid         = AttrValue.AVBool True }
+          , HasMatchingCertificate =
+              \(p : Text) ->
+                toMap { matching_certificate = AttrValue.AVText p }
+          }
+          s
+
+let zfsStateAttrs =
+      \(s : ZfsState) ->
+        merge
+          { Exist = toMap { exist = AttrValue.AVBool True }
+          , HasProperty =
+              \(rec : List { mapKey : Text, mapValue : Text }) ->
+                toMap
+                  { property =
+                      AttrValue.AVRecord (textRecToAttrLeafRec rec)
+                  }
+          }
+          s
+
+-- docker_container is a mixed-wildcard kind: known attr keys (exist/running/
+-- volume) are typed in the schema; inspect/inspect_include/inspection_not_include
+-- prefixed keys are accepted as wildcards. The Dhall encoder produces those
+-- prefix-tagged keys directly so the emitter can recover the original semantics.
+let dockerContainerStateAttrs =
+      \(s : DockerContainerState) ->
+        merge
+          { Exist   = toMap { exist   = AttrValue.AVBool True }
+          , Running = toMap { running = AttrValue.AVBool True }
+          , HasVolume =
+              \(v : { containerPath : Text, hostPath : Text }) ->
+                toMap
+                  { volume =
+                      AttrValue.AVList
+                        [ AttrLeaf.ALText v.containerPath
+                        , AttrLeaf.ALText v.hostPath
+                        ]
+                  }
+          , InspectEqText =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          , InspectEqNat =
+              \(p : { keyPath : Text, value : Natural }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVNat p.value
+                  }
+                ]
+          , InspectEqBool =
+              \(p : { keyPath : Text, value : Bool }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVBool p.value
+                  }
+                ]
+          , InspectEqSymbol =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVSymbol p.value
+                  }
+                ]
+          , InspectInclude =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect_include:" ++ p.keyPath
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          , InspectionNotInclude =
+              \(p : { key : Text, value : Text }) ->
+                [ { mapKey = "inspection_not_include:" ++ p.key
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          }
+          s
+
+let dockerImageStateAttrs =
+      \(s : DockerImageState) ->
+        merge
+          { Exist = toMap { exist = AttrValue.AVBool True }
+          , InspectEqText =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          , InspectEqNat =
+              \(p : { keyPath : Text, value : Natural }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVNat p.value
+                  }
+                ]
+          , InspectEqBool =
+              \(p : { keyPath : Text, value : Bool }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVBool p.value
+                  }
+                ]
+          , InspectEqSymbol =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect:" ++ p.keyPath
+                  , mapValue = AttrValue.AVSymbol p.value
+                  }
+                ]
+          , InspectInclude =
+              \(p : { keyPath : Text, value : Text }) ->
+                [ { mapKey = "inspect_include:" ++ p.keyPath
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          , InspectionNotInclude =
+              \(p : { key : Text, value : Text }) ->
+                [ { mapKey = "inspection_not_include:" ++ p.key
+                  , mapValue = AttrValue.AVText p.value
+                  }
+                ]
+          }
+          s
+
 -- Smart constructors --------------------------------------------------------
 
 let service
@@ -797,6 +1109,121 @@ let windowsRegistryKey
         , attrs = windowsRegistryKeyStateAttrs s
         }
 
+-- Phase 3 smart constructors -------------------------------------------------
+
+let lxc
+    : Text -> LxcState -> Assertion
+    = \(name : Text) ->
+      \(s : LxcState) ->
+        { kind = "lxc", primaryKey = name, attrs = lxcStateAttrs s }
+
+let mailAlias
+    : Text -> MailAliasState -> Assertion
+    = \(name : Text) ->
+      \(s : MailAliasState) ->
+        { kind = "mail_alias", primaryKey = name, attrs = mailAliasStateAttrs s }
+
+let ppa
+    : Text -> PpaState -> Assertion
+    = \(name : Text) ->
+      \(s : PpaState) ->
+        { kind = "ppa", primaryKey = name, attrs = ppaStateAttrs s }
+
+let yumrepo
+    : Text -> YumrepoState -> Assertion
+    = \(name : Text) ->
+      \(s : YumrepoState) ->
+        { kind = "yumrepo", primaryKey = name, attrs = yumrepoStateAttrs s }
+
+let iisAppPool
+    : Text -> IisAppPoolState -> Assertion
+    = \(name : Text) ->
+      \(s : IisAppPoolState) ->
+        { kind = "iis_app_pool"
+        , primaryKey = name
+        , attrs = iisAppPoolStateAttrs s
+        }
+
+let iisWebsite
+    : Text -> IisWebsiteState -> Assertion
+    = \(name : Text) ->
+      \(s : IisWebsiteState) ->
+        { kind = "iis_website"
+        , primaryKey = name
+        , attrs = iisWebsiteStateAttrs s
+        }
+
+let mysqlConfig
+    : Text -> MysqlConfigState -> Assertion
+    = \(name : Text) ->
+      \(s : MysqlConfigState) ->
+        { kind = "mysql_config"
+        , primaryKey = name
+        , attrs = mysqlConfigStateAttrs s
+        }
+
+-- phpConfig: single-arg form. The describe block becomes
+-- @describe php_config('default_mimetype') do@.
+let phpConfig
+    : Text -> PhpConfigState -> Assertion
+    = \(name : Text) ->
+      \(s : PhpConfigState) ->
+        { kind = "php_config"
+        , primaryKey = name
+        , attrs = phpConfigStateAttrs s
+        }
+
+-- phpConfigWithIni: two-arg form. The encoder injects an extra @_ini@
+-- attribute that the emitter consumes during header generation to produce
+-- @describe php_config('display_errors', :ini => '/etc/php/7.1/fpm/php.ini') do@.
+let phpConfigWithIni
+    : Text -> Text -> PhpConfigState -> Assertion
+    = \(name : Text) ->
+      \(iniPath : Text) ->
+      \(s : PhpConfigState) ->
+        { kind = "php_config"
+        , primaryKey = name
+        , attrs =
+            phpConfigStateAttrs s
+              # [ { mapKey = "_ini"
+                  , mapValue = AttrValue.AVText iniPath
+                  }
+                ]
+        }
+
+let x509PrivateKey
+    : Text -> X509PrivateKeyState -> Assertion
+    = \(path : Text) ->
+      \(s : X509PrivateKeyState) ->
+        { kind = "x509_private_key"
+        , primaryKey = path
+        , attrs = x509PrivateKeyStateAttrs s
+        }
+
+let zfs
+    : Text -> ZfsState -> Assertion
+    = \(name : Text) ->
+      \(s : ZfsState) ->
+        { kind = "zfs", primaryKey = name, attrs = zfsStateAttrs s }
+
+let dockerContainer
+    : Text -> DockerContainerState -> Assertion
+    = \(name : Text) ->
+      \(s : DockerContainerState) ->
+        { kind = "docker_container"
+        , primaryKey = name
+        , attrs = dockerContainerStateAttrs s
+        }
+
+let dockerImage
+    : Text -> DockerImageState -> Assertion
+    = \(name : Text) ->
+      \(s : DockerImageState) ->
+        { kind = "docker_image"
+        , primaryKey = name
+        , attrs = dockerImageStateAttrs s
+        }
+
 in  { AttrValue         = AttrValue
     , AttrLeaf          = AttrLeaf
     , CompareOp         = CompareOp
@@ -860,5 +1287,31 @@ in  { AttrValue         = AttrValue
     , cron                  = cron
     , x509Certificate       = x509Certificate
     , windowsRegistryKey    = windowsRegistryKey
+    -- Phase 3: serverspec.org coverage completion
+    , LxcState              = LxcState
+    , MailAliasState        = MailAliasState
+    , PpaState              = PpaState
+    , YumrepoState          = YumrepoState
+    , IisAppPoolState       = IisAppPoolState
+    , IisWebsiteState       = IisWebsiteState
+    , MysqlConfigState      = MysqlConfigState
+    , PhpConfigState        = PhpConfigState
+    , X509PrivateKeyState   = X509PrivateKeyState
+    , ZfsState              = ZfsState
+    , DockerContainerState  = DockerContainerState
+    , DockerImageState      = DockerImageState
+    , lxc                   = lxc
+    , mailAlias             = mailAlias
+    , ppa                   = ppa
+    , yumrepo               = yumrepo
+    , iisAppPool            = iisAppPool
+    , iisWebsite            = iisWebsite
+    , mysqlConfig           = mysqlConfig
+    , phpConfig             = phpConfig
+    , phpConfigWithIni      = phpConfigWithIni
+    , x509PrivateKey        = x509PrivateKey
+    , zfs                   = zfs
+    , dockerContainer       = dockerContainer
+    , dockerImage           = dockerImage
     , targetBackend     = "serverspec"
     }

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -42,6 +42,12 @@ backendAllowedKinds = \case
     , "linux_kernel_parameter", "cgroup"
     , "windows_feature", "windows_registry_key"
     , "x509_certificate", "cron"
+    -- Phase 3: serverspec.org coverage completion
+    , "lxc", "mail_alias", "ppa", "yumrepo"
+    , "iis_app_pool", "iis_website"
+    , "mysql_config", "php_config"
+    , "x509_private_key", "zfs"
+    , "docker_container", "docker_image"
     ]
   _            -> []
 

--- a/src/PanInfraSpec/DumpPlan.hs
+++ b/src/PanInfraSpec/DumpPlan.hs
@@ -67,14 +67,16 @@ renderLeaf = \case
   ALNat    n -> tshow n
   ALBool   b -> if b then "True" else "False"
   ALSymbol s -> ":" <> s
+  ALRegex  p -> "/" <> p <> "/"
 
 renderOp :: CompareOp -> Text
 renderOp = \case
-  OpLt -> "<"
-  OpLe -> "<="
-  OpGt -> ">"
-  OpGe -> ">="
-  OpEq -> "=="
+  OpLt    -> "<"
+  OpLe    -> "<="
+  OpGt    -> ">"
+  OpGe    -> ">="
+  OpEq    -> "=="
+  OpMatch -> "=~"
 
 quoted :: Text -> Text
 quoted t = "\"" <> t <> "\""

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -152,6 +152,47 @@ serverspecSchema = Map.fromList
   , ("linux_kernel_parameter", Map.fromList
       [ ("value", ATText) ])
   , ("cgroup", Map.empty)  -- wildcard kind: dynamic parameter names
+  -- Phase 3: serverspec.org coverage completion
+  , ("lxc", Map.fromList
+      [ ("exist", ATBool), ("running", ATBool) ])
+  , ("mail_alias", Map.fromList
+      [ ("aliased_to", ATText) ])
+  , ("ppa", Map.fromList
+      [ ("exist", ATBool), ("enabled", ATBool) ])
+  , ("yumrepo", Map.fromList
+      [ ("exist", ATBool), ("enabled", ATBool) ])
+  , ("iis_app_pool", Map.fromList
+      [ ("exist", ATBool), ("dotnet_version", ATText) ])
+  , ("iis_website", Map.fromList
+      [ ("exist",         ATBool)
+      , ("enabled",       ATBool)
+      , ("running",       ATBool)
+      , ("in_app_pool",   ATText)
+      , ("physical_path", ATText)
+      ])
+  , ("mysql_config", Map.fromList
+      [ ("value", ATCompare) ])
+  , ("php_config", Map.fromList
+      [ ("value", ATCompare)
+      , ("_ini",  ATText)  -- header injection sentinel; consumed by formatGroup
+      ])
+  , ("x509_private_key", Map.fromList
+      [ ("encrypted",            ATBool)
+      , ("not_encrypted",        ATBool)
+      , ("valid",                ATBool)
+      , ("matching_certificate", ATText)
+      ])
+  , ("zfs", Map.fromList
+      [ ("exist",    ATBool)
+      , ("property", ATRecord)
+      ])
+  , ("docker_container", Map.fromList
+      [ ("exist",   ATBool)
+      , ("running", ATBool)
+      , ("volume",  ATList)
+      ])
+  , ("docker_image", Map.fromList
+      [ ("exist", ATBool) ])
   ]
 
 -- | Kinds whose @describe@ block takes no primary-key argument
@@ -174,6 +215,18 @@ wildcardValueTags :: Map Text [AttrTag]
 wildcardValueTags = Map.fromList
   [ ("routing_table", [ATText, ATRecord])
   , ("cgroup",        [ATText])
+  ]
+
+-- | Mixed-wildcard kinds: their schema lists known attr keys with fixed types,
+-- but unknown keys are accepted as wildcard values matching the listed
+-- 'AttrTag's. The Docker resources use this so @inspect:<keypath>@ /
+-- @inspect_include:<keypath>@ / @inspection_not_include:<key>@ attribute keys
+-- (whose suffix varies per inspection target) can flow through validation
+-- without enumerating every possible Docker JSON path in the schema.
+mixedWildcardKinds :: Map Text [AttrTag]
+mixedWildcardKinds = Map.fromList
+  [ ("docker_container", [ATText, ATNat, ATBool, ATSymbol])
+  , ("docker_image",     [ATText, ATNat, ATBool, ATSymbol])
   ]
 
 tagOf :: AttrValue -> AttrTag
@@ -225,14 +278,20 @@ validateAssertion a@(Assertion k pk attrs) = do
              Left $ "wildcard kind " <> k <> " accepts "
                  <> T.intercalate "/" (map showTag allowed)
                  <> "; got " <> showTag actual <> " for key " <> key
-      else do
-        expected <- case Map.lookup key kindSchema of
-          Just t  -> Right t
+      else case Map.lookup key kindSchema of
+        Just expected -> do
+          let actual = tagOf val
+          unless (actual == expected) $
+            Left $ "wrong attr type for " <> k <> "." <> key
+                <> ": expected " <> showTag expected <> ", got " <> showTag actual
+        Nothing -> case Map.lookup k mixedWildcardKinds of
+          Just allowed ->
+            let actual = tagOf val
+            in unless (actual `elem` allowed) $
+                 Left $ "mixed-wildcard kind " <> k <> " accepts "
+                     <> T.intercalate "/" (map showTag allowed)
+                     <> "; got " <> showTag actual <> " for key " <> key
           Nothing -> Left ("unknown attrs key for kind " <> k <> ": " <> key)
-        let actual = tagOf val
-        unless (actual == expected) $
-          Left $ "wrong attr type for " <> k <> "." <> key
-              <> ": expected " <> showTag expected <> ", got " <> showTag actual
   when (k == "port") $
     case TR.decimal pk :: Either String (Natural, Text) of
       Right (_, rest) | T.null rest -> Right ()
@@ -438,6 +497,58 @@ formatItLine "windows_registry_key" "property_args" (AVList xs) =
   "it { should have_property " <> renderArgList xs <> " }"
 formatItLine "windows_registry_key" "property_value_args" (AVList xs) =
   "it { should have_property_value " <> renderArgList xs <> " }"
+-- Phase 3 (serverspec.org coverage completion) -------------------------------
+-- lxc
+formatItLine "lxc"        "exist"          _          = "it { should exist }"
+formatItLine "lxc"        "running"        _          = "it { should be_running }"
+-- mail_alias
+formatItLine "mail_alias" "aliased_to"     (AVText r) =
+  "it { should be_aliased_to " <> rubyString r <> " }"
+-- ppa
+formatItLine "ppa"        "exist"          _          = "it { should exist }"
+formatItLine "ppa"        "enabled"        _          = "it { should be_enabled }"
+-- yumrepo
+formatItLine "yumrepo"    "exist"          _          = "it { should exist }"
+formatItLine "yumrepo"    "enabled"        _          = "it { should be_enabled }"
+-- iis_app_pool
+formatItLine "iis_app_pool" "exist"          _          = "it { should exist }"
+formatItLine "iis_app_pool" "dotnet_version" (AVText v) =
+  "it { should have_dotnet_version(" <> rubyString v <> ") }"
+-- iis_website
+formatItLine "iis_website" "exist"         _          = "it { should exist }"
+formatItLine "iis_website" "enabled"       _          = "it { should be_enabled }"
+formatItLine "iis_website" "running"       _          = "it { should be_running }"
+formatItLine "iis_website" "in_app_pool"   (AVText p) =
+  "it { should be_in_app_pool(" <> rubyString p <> ") }"
+formatItLine "iis_website" "physical_path" (AVText p) =
+  "it { should have_physical_path(" <> rubyString p <> ") }"
+-- mysql_config / php_config: single value attr; renderAttrs handles the
+-- normal compound flow. The single-key fallback below covers any future
+-- code path that reaches formatItLine directly.
+formatItLine "mysql_config" "value" (AVCompare op leaf) =
+  "its(:value) { should " <> renderCompareRuby op (renderLeafRuby leaf) <> " }"
+formatItLine "php_config"   "value" (AVCompare op leaf) =
+  "its(:value) { should " <> renderCompareRuby op (renderLeafRuby leaf) <> " }"
+-- x509_private_key
+formatItLine "x509_private_key" "encrypted"     _          = "it { should be_encrypted }"
+formatItLine "x509_private_key" "not_encrypted" _          = "it { should_not be_encrypted }"
+formatItLine "x509_private_key" "valid"         _          = "it { should be_valid }"
+formatItLine "x509_private_key" "matching_certificate" (AVText p) =
+  "it { should have_matching_certificate(" <> rubyString p <> ") }"
+-- zfs
+formatItLine "zfs" "exist"    _              = "it { should exist }"
+formatItLine "zfs" "property" (AVRecord kw)  =
+  "it { should have_property " <> renderStringKwargs kw <> " }"
+-- docker_container fixed-schema fallbacks. inspect:* keys are handled in
+-- renderAttrs and never flow through here.
+formatItLine "docker_container" "exist"   _ = "it { should exist }"
+formatItLine "docker_container" "running" _ = "it { should be_running }"
+formatItLine "docker_container" "volume"  (AVList xs) = case xs of
+  [c, h] -> "it { should have_volume(" <> renderLeafRuby c <> ", "
+              <> renderLeafRuby h <> ") }"
+  _      -> "it { should have_volume " <> renderArgList xs <> " }"
+-- docker_image fixed-schema fallback
+formatItLine "docker_image" "exist" _ = "it { should exist }"
 formatItLine k key _ =
   "# UNREACHABLE: unmatched (" <> pretty k <> ", " <> pretty key <> ")"
 
@@ -456,6 +567,7 @@ renderLeafRuby = \case
   ALNat    n -> pretty n
   ALBool   b -> if b then "true" else "false"
   ALSymbol s -> ":" <> pretty s
+  ALRegex  p -> "/" <> pretty p <> "/"
 
 -- | Render a record as @:k => v, :k => v@ (Ruby keyword-arg syntax). Used
 -- by @host.be_reachable.with@, @routing_table.have_entry@, etc.
@@ -463,6 +575,15 @@ renderRecordKwargs :: Map Text AttrLeaf -> Doc ann
 renderRecordKwargs m =
   hsep $ punctuate ","
     [ ":" <> pretty k <+> "=>" <+> renderLeafRuby v
+    | (k, v) <- Map.toAscList m
+    ]
+
+-- | Render a record as @'k' => v, 'k2' => v2@ (Ruby hash literal with string
+-- keys). Used by @zfs.have_property@ and @docker_container.inspection_not_include@.
+renderStringKwargs :: Map Text AttrLeaf -> Doc ann
+renderStringKwargs m =
+  hsep $ punctuate ","
+    [ rubyString k <+> "=>" <+> renderLeafRuby v
     | (k, v) <- Map.toAscList m
     ]
 
@@ -476,11 +597,12 @@ renderArgList xs = hsep $ punctuate "," (map renderLeafRuby xs)
 -- etc., matching idiomatic Serverspec/RSpec.
 renderCompareRuby :: CompareOp -> Doc ann -> Doc ann
 renderCompareRuby op v = case op of
-  OpEq -> "eq" <+> v
-  OpLt -> "be" <+> "<"  <+> v
-  OpLe -> "be" <+> "<=" <+> v
-  OpGt -> "be" <+> ">"  <+> v
-  OpGe -> "be" <+> ">=" <+> v
+  OpEq    -> "eq" <+> v
+  OpLt    -> "be" <+> "<"  <+> v
+  OpLe    -> "be" <+> "<=" <+> v
+  OpGt    -> "be" <+> ">"  <+> v
+  OpGe    -> "be" <+> ">=" <+> v
+  OpMatch -> "match" <+> v
 
 -- | Render the @it { ... }@ lines of a @describe@ block. Indirection over
 -- 'formatItLine' so that compound matchers can fold multiple attribute keys
@@ -577,8 +699,47 @@ renderAttrs "windows_registry_key" attrs =
       _ -> formatItLine "windows_registry_key" key val
   | (key, val) <- Map.toAscList attrs
   ]
+-- Docker resources use prefix-tagged attr keys to encode dynamic inspect
+-- paths (@inspect:Path@, @inspect:HostConfig.NetworkMode@, etc.) without
+-- adding a recursive AttrValue constructor. Strip the prefix here and emit
+-- the corresponding Ruby. Fixed-schema keys (exist/running/volume) flow
+-- through formatItLine.
+renderAttrs "docker_container" attrs =
+  [ renderDockerAttr "docker_container" key val | (key, val) <- Map.toAscList attrs ]
+renderAttrs "docker_image" attrs =
+  [ renderDockerAttr "docker_image" key val | (key, val) <- Map.toAscList attrs ]
 renderAttrs k attrs =
   [ formatItLine k key val | (key, val) <- Map.toAscList attrs ]
+
+-- | Phase 3: Docker prefix-tagged attribute renderer. Recognizes three
+-- semantic prefixes for the inspect-family of matchers; falls back to
+-- 'formatItLine' for fixed-schema keys.
+renderDockerAttr :: Text -> Text -> AttrValue -> Doc ann
+renderDockerAttr k key val
+  | Just keyPath <- T.stripPrefix "inspect:" key =
+      "its([" <> rubyString keyPath <> "]) { should eq "
+        <> renderInspectScalar val <> " }"
+  | Just keyPath <- T.stripPrefix "inspect_include:" key =
+      "its([" <> rubyString keyPath <> "]) { should include "
+        <> renderInspectScalar val <> " }"
+  | Just hashKey <- T.stripPrefix "inspection_not_include:" key =
+      case val of
+        AVText v ->
+          "its(:inspection) { should_not include "
+            <> rubyString hashKey <> " => " <> rubyString v <> " }"
+        _ -> formatItLine k key val
+  | otherwise = formatItLine k key val
+
+-- | Render a scalar 'AttrValue' as the right-hand side of an inspect
+-- matcher. Compound values are not expected here; they would have been
+-- rejected by validation.
+renderInspectScalar :: AttrValue -> Doc ann
+renderInspectScalar = \case
+  AVText   t -> rubyString t
+  AVNat    n -> pretty n
+  AVBool   b -> if b then "true" else "false"
+  AVSymbol s -> ":" <> pretty s
+  v          -> pretty (showVal v)
 
 -- | Phase 2 follow-up: split off the @file@ permission chain for one base
 -- matcher (@readable@/@writable@/@executable@). Returns the chained Ruby
@@ -688,15 +849,27 @@ lookupText k m = case Map.lookup k m of
 
 -- | Render one merged 'Assertion' as a @describe ... do ... end@ block.
 -- Singleton kinds (see 'singletonKinds') drop the @(<primaryKey>)@ argument.
+-- The @php_config@ kind injects an @:ini => '<path>'@ keyword arg into the
+-- header when the @_ini@ sentinel attribute is present (see Dhall
+-- @phpConfigWithIni@).
 formatGroup :: Assertion -> Either Text (Doc ann)
-formatGroup (Assertion k pk attrs) = do
+formatGroup (Assertion k pk attrs0) = do
   let resource = pretty (kindToRubyResource k)
+      (iniArg, attrs)
+        | k == "php_config"
+        , Just (AVText p) <- Map.lookup "_ini" attrs0
+        = (Just p, Map.delete "_ini" attrs0)
+        | otherwise
+        = (Nothing, attrs0)
   header <-
     if Set.member k singletonKinds
       then Right ("describe" <+> resource <+> "do")
       else do
         hd <- primaryDoc k pk
-        Right ("describe" <+> resource <> "(" <> hd <> ")" <+> "do")
+        let args = case iniArg of
+              Nothing -> hd
+              Just p  -> hd <> "," <+> ":ini" <+> "=>" <+> rubyString p
+        Right ("describe" <+> resource <> "(" <> args <> ")" <+> "do")
   let body = vsep (renderAttrs k attrs)
   pure $ vsep [header, indent 2 body, "end"]
 

--- a/src/PanInfraSpec/IR.hs
+++ b/src/PanInfraSpec/IR.hs
@@ -44,18 +44,19 @@ instance Dhall.FromDhall Node where
       <*> Dhall.field "tags"     Dhall.auto
 
 -- | Comparison operator for 'AVCompare'. Mirrors the Dhall union
--- @< Lt | Le | Gt | Ge | Eq >@. Used for matchers like
--- @validity_in_days should be > 30@.
-data CompareOp = OpLt | OpLe | OpGt | OpGe | OpEq
+-- @< Lt | Le | Gt | Ge | Eq | Match >@. Used for matchers like
+-- @validity_in_days should be > 30@ and @value should match /pattern/@.
+data CompareOp = OpLt | OpLe | OpGt | OpGe | OpEq | OpMatch
   deriving stock (Show, Eq, Generic)
 
 instance Dhall.FromDhall CompareOp where
   autoWith _ = Dhall.union
-    (  (OpLt <$ Dhall.constructor "Lt" Dhall.unit)
-    <> (OpLe <$ Dhall.constructor "Le" Dhall.unit)
-    <> (OpGt <$ Dhall.constructor "Gt" Dhall.unit)
-    <> (OpGe <$ Dhall.constructor "Ge" Dhall.unit)
-    <> (OpEq <$ Dhall.constructor "Eq" Dhall.unit)
+    (  (OpLt    <$ Dhall.constructor "Lt"    Dhall.unit)
+    <> (OpLe    <$ Dhall.constructor "Le"    Dhall.unit)
+    <> (OpGt    <$ Dhall.constructor "Gt"    Dhall.unit)
+    <> (OpGe    <$ Dhall.constructor "Ge"    Dhall.unit)
+    <> (OpEq    <$ Dhall.constructor "Eq"    Dhall.unit)
+    <> (OpMatch <$ Dhall.constructor "Match" Dhall.unit)
     )
 
 -- | Scalar leaf carried inside compound 'AttrValue' constructors
@@ -67,6 +68,7 @@ data AttrLeaf
   | ALNat    Natural
   | ALBool   Bool
   | ALSymbol Text
+  | ALRegex  Text   -- ^ Ruby regex literal payload (without surrounding @/.../@).
   deriving stock (Show, Eq, Generic)
 
 instance Dhall.FromDhall AttrLeaf where
@@ -75,6 +77,7 @@ instance Dhall.FromDhall AttrLeaf where
     <> (ALNat    <$> Dhall.constructor "ALNat"    Dhall.auto)
     <> (ALBool   <$> Dhall.constructor "ALBool"   Dhall.auto)
     <> (ALSymbol <$> Dhall.constructor "ALSymbol" Dhall.auto)
+    <> (ALRegex  <$> Dhall.constructor "ALRegex"  Dhall.auto)
     )
 
 -- | Attribute value carried inside an 'Assertion'. Mirrors the Dhall union

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -27,6 +27,21 @@ describe default_gateway do
   its(:ipaddress) { should eq '10.0.1.1' }
 end
 
+describe docker_container('focused_curie') do
+  it { should exist }
+  its(['HostConfig.NetworkMode']) { should eq 'bridge' }
+  its(['Path']) { should eq '/bin/sh' }
+  it { should be_running }
+  it { should have_volume('/tmp', '/data') }
+end
+
+describe docker_image('busybox:latest') do
+  it { should exist }
+  its(['Architecture']) { should eq 'amd64' }
+  its(['Config.Cmd']) { should include '/bin/sh' }
+  its(:inspection) { should_not include 'Architecture' => 'i386' }
+end
+
 describe file('/etc/hosts') do
   it { should be_file }
 end
@@ -96,6 +111,19 @@ describe host('example.jp') do
   it { should be_resolvable }
 end
 
+describe iis_app_pool('Default App Pool') do
+  it { should have_dotnet_version('2.0') }
+  it { should exist }
+end
+
+describe iis_website('Default Website') do
+  it { should be_enabled }
+  it { should exist }
+  it { should be_in_app_pool('Default App Pool') }
+  it { should have_physical_path('C:\\inetpub\\www') }
+  it { should be_running }
+end
+
 describe interface('eth0') do
   it { should exist }
   it { should have_ipv4_address '10.0.1.10' }
@@ -133,18 +161,56 @@ describe linux_kernel_parameter('net.ipv4.ip_forward') do
   its(:value) { should eq '1' }
 end
 
+describe lxc('ct01') do
+  it { should exist }
+  it { should be_running }
+end
+
+describe mail_alias('daemon') do
+  it { should be_aliased_to 'root' }
+end
+
 describe mount('/data') do
   its(:device) { should eq '/dev/sda1' }
   its(:fstype) { should eq 'ext4' }
   it { should be_mounted }
 end
 
+describe mysql_config('innodb-buffer-pool-size') do
+  its(:value) { should be > 100000000 }
+end
+
+describe mysql_config('socket') do
+  its(:value) { should eq '/tmp/mysql.sock' }
+end
+
 describe package('nginx') do
   it { should be_installed }
 end
 
+describe php_config('default_mimetype') do
+  its(:value) { should eq 'text/html' }
+end
+
+describe php_config('display_errors', :ini => '/etc/php/7.1/fpm/php.ini') do
+  its(:value) { should eq 1 }
+end
+
+describe php_config('mbstring.http_output_conv_mimetypes') do
+  its(:value) { should match /application/ }
+end
+
+describe php_config('session.cache_expire') do
+  its(:value) { should eq 180 }
+end
+
 describe port(80) do
   it { should be_listening.with('tcp') }
+end
+
+describe ppa('launchpad-username/ppa-name') do
+  it { should be_enabled }
+  it { should exist }
 end
 
 describe process('nginx') do
@@ -198,4 +264,20 @@ end
 
 describe x509_certificate('/etc/ssl/cert.pem') do
   its(:validity_in_days) { should be > 30 }
+end
+
+describe x509_private_key('/my/private/server-key.pem') do
+  it { should have_matching_certificate('/my/certs/server-cert.pem') }
+  it { should_not be_encrypted }
+  it { should be_valid }
+end
+
+describe yumrepo('epel') do
+  it { should be_enabled }
+  it { should exist }
+end
+
+describe zfs('rpool') do
+  it { should exist }
+  it { should have_property 'compression' => 'off', 'mountpoint' => '/rpool' }
 end

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -133,5 +133,81 @@ in  Plan.make Spec.targetBackend
           , Spec.process "nginx"
               (Spec.ProcessState.HasArgs "-c /etc/nginx/nginx.conf")
           , Spec.process "nginx" (Spec.ProcessState.HasCount 4)
+          -- Phase 3: serverspec.org coverage completion ----------------------
+          , Spec.lxc "ct01" Spec.LxcState.Exist
+          , Spec.lxc "ct01" Spec.LxcState.Running
+          , Spec.mailAlias "daemon" (Spec.MailAliasState.AliasedTo "root")
+          , Spec.ppa "launchpad-username/ppa-name" Spec.PpaState.Exist
+          , Spec.ppa "launchpad-username/ppa-name" Spec.PpaState.Enabled
+          , Spec.yumrepo "epel" Spec.YumrepoState.Exist
+          , Spec.yumrepo "epel" Spec.YumrepoState.Enabled
+          , Spec.iisAppPool "Default App Pool" Spec.IisAppPoolState.Exist
+          , Spec.iisAppPool "Default App Pool"
+              (Spec.IisAppPoolState.HasDotnetVersion "2.0")
+          , Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Exist
+          , Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Enabled
+          , Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Running
+          , Spec.iisWebsite "Default Website"
+              (Spec.IisWebsiteState.InAppPool "Default App Pool")
+          , Spec.iisWebsite "Default Website"
+              (Spec.IisWebsiteState.HasPhysicalPath "C:\\inetpub\\www")
+          , Spec.mysqlConfig "innodb-buffer-pool-size"
+              ( Spec.MysqlConfigState.Compare
+                  { op = Spec.CompareOp.Gt, value = 100000000 }
+              )
+          , Spec.mysqlConfig "socket"
+              (Spec.MysqlConfigState.EqText "/tmp/mysql.sock")
+          , Spec.phpConfig "default_mimetype"
+              (Spec.PhpConfigState.EqText "text/html")
+          , Spec.phpConfig "session.cache_expire"
+              (Spec.PhpConfigState.EqNat 180)
+          , Spec.phpConfig "mbstring.http_output_conv_mimetypes"
+              (Spec.PhpConfigState.Match "application")
+          , Spec.phpConfigWithIni "display_errors" "/etc/php/7.1/fpm/php.ini"
+              (Spec.PhpConfigState.EqNat 1)
+          , Spec.x509PrivateKey "/my/private/server-key.pem"
+              Spec.X509PrivateKeyState.NotEncrypted
+          , Spec.x509PrivateKey "/my/private/server-key.pem"
+              Spec.X509PrivateKeyState.Valid
+          , Spec.x509PrivateKey "/my/private/server-key.pem"
+              ( Spec.X509PrivateKeyState.HasMatchingCertificate
+                  "/my/certs/server-cert.pem"
+              )
+          , Spec.zfs "rpool" Spec.ZfsState.Exist
+          , Spec.zfs "rpool"
+              ( Spec.ZfsState.HasProperty
+                  [ { mapKey = "compression", mapValue = "off" }
+                  , { mapKey = "mountpoint",  mapValue = "/rpool" }
+                  ]
+              )
+          , Spec.dockerContainer "focused_curie"
+              Spec.DockerContainerState.Exist
+          , Spec.dockerContainer "focused_curie"
+              Spec.DockerContainerState.Running
+          , Spec.dockerContainer "focused_curie"
+              ( Spec.DockerContainerState.HasVolume
+                  { containerPath = "/tmp", hostPath = "/data" }
+              )
+          , Spec.dockerContainer "focused_curie"
+              ( Spec.DockerContainerState.InspectEqText
+                  { keyPath = "Path", value = "/bin/sh" }
+              )
+          , Spec.dockerContainer "focused_curie"
+              ( Spec.DockerContainerState.InspectEqText
+                  { keyPath = "HostConfig.NetworkMode", value = "bridge" }
+              )
+          , Spec.dockerImage "busybox:latest" Spec.DockerImageState.Exist
+          , Spec.dockerImage "busybox:latest"
+              ( Spec.DockerImageState.InspectEqText
+                  { keyPath = "Architecture", value = "amd64" }
+              )
+          , Spec.dockerImage "busybox:latest"
+              ( Spec.DockerImageState.InspectInclude
+                  { keyPath = "Config.Cmd", value = "/bin/sh" }
+              )
+          , Spec.dockerImage "busybox:latest"
+              ( Spec.DockerImageState.InspectionNotInclude
+                  { key = "Architecture", value = "i386" }
+              )
           ]
       ]

--- a/test/Roundtrip/DhallEncodingTest.hs
+++ b/test/Roundtrip/DhallEncodingTest.hs
@@ -14,16 +14,16 @@ attrValueU :: Text
 attrValueU =
   "< AVText : Text | AVNat : Natural | AVBool : Bool \
   \| AVSymbol : Text \
-  \| AVList : List < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text > \
-  \| AVRecord : List { mapKey : Text, mapValue : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text > } \
-  \| AVCompare : { op : < Lt | Le | Gt | Ge | Eq >, value : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text > } \
+  \| AVList : List < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > \
+  \| AVRecord : List { mapKey : Text, mapValue : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > } \
+  \| AVCompare : { op : < Lt | Le | Gt | Ge | Eq | Match >, value : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > } \
   \>"
 
 attrLeafU :: Text
-attrLeafU = "< ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text >"
+attrLeafU = "< ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text >"
 
 compareOpU :: Text
-compareOpU = "< Lt | Le | Gt | Ge | Eq >"
+compareOpU = "< Lt | Le | Gt | Ge | Eq | Match >"
 
 tests :: TestTree
 tests = testGroup "Dhall round-trip"


### PR DESCRIPTION
## Summary
- Add the 12 resource types still missing from serverspec.org/resource_types: `docker_container`, `docker_image`, `iis_app_pool`, `iis_website`, `lxc`, `mail_alias`, `mysql_config`, `php_config`, `ppa`, `x509_private_key`, `yumrepo`, `zfs`. Coverage is now 40/40.
- Every documented matcher per resource is supported, including `its(['HostConfig.NetworkMode'])` (Docker dotted-path inspect), `should match /pattern/` (php_config regex), `should_not be_encrypted` (x509_private_key negation), `php_config('k', :ini => '/path')` (optional `:ini` arg), and `have_property '<k>' => '<v>'` (zfs string-keyed hash literal).
- IR extensions: `CompareOp` gains `OpMatch`, `AttrLeaf` gains `ALRegex`. A new `mixedWildcardKinds` table lets Docker resources mix a fixed schema (exist/running/volume) with prefix-tagged wildcard keys (`inspect:`, `inspect_include:`, `inspection_not_include:`) so dynamic docker-inspect paths flow through validation without enumerating every JSON field.
- New emit helpers: `renderStringKwargs` for Ruby string-keyed hash literals, and a `formatGroup` extension that consumes the `_ini` sentinel attribute to inject the keyword arg into the php_config describe header.
- Layer-2 allowlist (`backendAllowedKinds`) and Roundtrip test inline Dhall type literals are updated in lockstep with the new union constructors.

## Test plan
- [x] `cabal build all` succeeds with `-Wall -Werror`.
- [x] `cabal test` passes all 35 tests (defense-in-depth, Dhall round-trip, property tests with 100 cases each, synthetic 100-host, SoT/Terraform, golden files).
- [x] Property tests `prop_emit_total_for_valid` and `prop_no_unreachable_in_output` cover the new fixed-schema kinds automatically via `serverspecSchema`.
- [x] Golden output (`test/Golden/expected/web01_spec.rb`) shows every new matcher rendered as the documented Ruby form.
- [x] Existing `examples/plan.dhall` still generates correctly with the extended prelude (record subtyping preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)