### PR TITLE
Split docs out of README and bump to 0.1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Haskell](https://img.shields.io/badge/language-Haskell-5D4F85)](https://www.haskell.org/)
 
-PanInfraSpec is a typed front-end for [Serverspec](https://serverspec.org/).
+PanInfraSpec is a Dhall front-end for [Serverspec](https://serverspec.org/).
 You describe your nodes and the assertions they should satisfy in
 [Dhall](https://dhall-lang.org/), and `paninfraspec-gen` produces the
 matching `*_spec.rb`, `spec_helper.rb`, and `Rakefile` for you. PanInfraSpec
@@ -106,29 +106,10 @@ receives the baseline check, the full nginx stack, *and* the Prometheus port.
 
 ## Loading inventory from Terraform state
 
-Instead of hand-writing `examples/inventory.dhall`, point at a
-`terraform.tfstate` JSON file:
-
-```sh
-cabal run paninfraspec-gen -- \
-  --from-terraform-state examples/terraform-state.json \
-  --plan                 examples/plan.dhall \
-  --target               serverspec \
-  --out                  /tmp/out
-```
-
-The Terraform adapter walks every `aws_instance` resource and applies the
-following tag conventions:
-
-| Field | Source | Fallback |
-|---|---|---|
-| `hostname` | `tags.Name` | `attributes.id`, then `<type>.<name>` |
-| `ip` | `attributes.private_ip` | `attributes.public_ip`, then `None` |
-| `role` | `tags.Role` | `"untagged"` |
-| `tags` | remaining tag *values* (Name & Role excluded) | `[]` |
-
-Other resource types (security groups, IAM, etc.) are skipped. Pass exactly
-one of `--inventory` or `--from-terraform-state`, not both.
+Instead of hand-writing an inventory, point `--from-terraform-state` at a
+`terraform.tfstate` JSON file and PanInfraSpec will derive nodes from every
+`aws_instance` resource. See [`docs/terraform.md`](./docs/terraform.md) for
+the tag conventions and a full example.
 
 ## Customising the output layout
 
@@ -196,47 +177,12 @@ not execute tests — those failures are surfaced by Serverspec itself.
 
 ## Resource catalogue
 
-The Dhall prelude in [`dhall/Serverspec.dhall`](./dhall/Serverspec.dhall)
-exposes the following smart constructors. Each one takes a primary key (the
-service name, port number, file path, etc.) and a state value drawn from the
-matching `*State` union.
+PanInfraSpec ships smart constructors for 26 Serverspec resource types
+(service, package, port, file, user, iptables, SELinux, cgroup, …). Each
+constructor takes a primary key plus a state value drawn from a typed union.
 
-| Resource | Constructor | States |
-|---|---|---|
-| Service | `service : Text -> ServiceState -> Assertion` | `Running`, `Enabled` |
-| Package | `package : Text -> PackageState -> Assertion` | `Installed` |
-| Port | `port : Natural -> PortState -> Assertion` | `Listening`, `WithProtocol : Text` |
-| Command | `command : Text -> CommandState -> Assertion` | `ExitCode : Natural` |
-| File | `file : Text -> FileState -> Assertion` | `Exist`, `OwnedBy : Text`, `GroupedInto : Text`, `Mode : Natural`, `Contains : Text` |
-| User | `user : Text -> UserState -> Assertion` | `Exist`, `HasUid : Natural`, `BelongsToGroup : Text`, `HasHomeDirectory : Text`, `HasLoginShell : Text` |
-| Group | `group : Text -> GroupState -> Assertion` | `Exist`, `HasGid : Natural` |
-| Process | `process : Text -> ProcessState -> Assertion` | `Running`, `RunByUser : Text` |
-| Mount | `mount : Text -> MountState -> Assertion` | `Mounted`, `OnDevice : Text`, `OfFstype : Text` |
-| Interface | `interface : Text -> InterfaceState -> Assertion` | `Exist`, `HasSpeed : Natural`, `HasIpv4Address : Text` |
-| Kernel module | `kernelModule : Text -> KernelModuleState -> Assertion` | `Loaded` |
-| Bond | `bond : Text -> BondState -> Assertion` | `Exist`, `HasInterface : Text` |
-| Bridge | `bridge : Text -> BridgeState -> Assertion` | `Exist`, `HasInterface : Text` |
-| Default gateway (singleton) | `defaultGateway : DefaultGatewayState -> Assertion` | `HasIpaddress : Text`, `HasInterface : Text` |
-| Host | `host : Text -> HostState -> Assertion` | `Resolvable`, `Reachable`, `HasIpaddress : Text` |
-| iptables | `iptables : Text -> IptablesState -> Assertion` | `HasRule : Text` |
-| ip6tables | `ip6tables : Text -> Ip6tablesState -> Assertion` | `HasRule : Text` |
-| ipfilter | `ipfilter : Text -> IpfilterState -> Assertion` | `HasRule : Text` |
-| ipnat | `ipnat : Text -> IpnatState -> Assertion` | `HasRule : Text` |
-| Routing table (singleton) | `routingTable : RoutingTableState -> Assertion` | `HasEntry : { destination : Text, gateway : Text }` |
-| SELinux (singleton) | `selinux : SelinuxState -> Assertion` | `Enforcing`, `Permissive`, `Disabled` |
-| SELinux module | `selinuxModule : Text -> SelinuxModuleState -> Assertion` | `Enabled`, `Installed` |
-| Linux audit system (singleton) | `linuxAuditSystem : LinuxAuditSystemState -> Assertion` | `Running`, `Enabled` |
-| Linux kernel parameter | `linuxKernelParameter : Text -> LinuxKernelParameterState -> Assertion` | `HasValue : Text` |
-| Cgroup | `cgroup : Text -> CgroupState -> Assertion` | `HasParameter : { name : Text, value : Text }` |
-
-To express more than one state for the same resource (e.g. nginx must be both
-running and enabled), write two assertions with the same primary key — they
-are merged into a single `describe` block in the generated Ruby.
-
-To add a new resource, extend `dhall/Serverspec.dhall` with a smart
-constructor and a state type, then add one entry to `formatItLine` in
-`src/PanInfraSpec/Emit/Serverspec.hs` mapping each attribute key to its Ruby
-DSL line.
+See [`docs/resources.md`](./docs/resources.md) for the full table of
+constructors, their state unions, and how to add a new resource.
 
 ## How it works
 
@@ -254,13 +200,12 @@ fails fast rather than emit Ruby that is guaranteed to fail at run time.
 The arrow above is drawn for Serverspec, but the AST and the emitter
 interface are backend-agnostic — Goss (YAML), InSpec, and Testinfra emitters
 are planned, and adding one is a new Dhall prelude plus a new emitter, with
-no changes to existing inputs. The full design is in
-[`specification.md`](./specification.md).
+no changes to existing inputs.
 
 ## See also
 
-- [`specification.md`](./specification.md) — full design (~730 lines, JP/EN
-  bilingual)
+- [`docs/resources.md`](./docs/resources.md) — full Serverspec resource catalogue
+- [`docs/terraform.md`](./docs/terraform.md) — loading inventory from a Terraform `tfstate` file
 - [`examples/`](./examples) — sample inventory, plan, and Terraform state
 - [`dhall/`](./dhall) — preludes you import from your own Dhall files
   (`Inventory.dhall`, `Serverspec.dhall`, `Plan.dhall`)

--- a/dhall/Inventory.dhall
+++ b/dhall/Inventory.dhall
@@ -1,6 +1,5 @@
 -- dhall/Inventory.dhall
 -- Backend-agnostic prelude for the inventory.
--- See specification.md §3.1.
 
 let Role = Text  -- organisations have different role vocabularies; keep as Text wrapper
 

--- a/dhall/Plan.dhall
+++ b/dhall/Plan.dhall
@@ -1,6 +1,6 @@
 -- dhall/Plan.dhall
 -- Selector and Mapping prelude. Backend-agnostic in shape, but pulls Assertion
--- from the chosen backend prelude. See specification.md §3.3.
+-- from the chosen backend prelude.
 
 let Selector =
       < SelAll

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -1,7 +1,7 @@
 -- dhall/Serverspec.dhall
 -- Per-backend Dhall prelude for Serverspec.
 -- Smart constructors enforce Resource × State pairing at the input boundary
--- (Defense-in-depth layer 1). See specification.md §3.2 / §5.4.
+-- (Defense-in-depth layer 1).
 
 let CompareOp = < Lt | Le | Gt | Ge | Eq | Match >
 

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -1,0 +1,43 @@
+# Resource catalogue
+
+The Dhall prelude in [`dhall/Serverspec.dhall`](../dhall/Serverspec.dhall)
+exposes the following smart constructors. Each one takes a primary key (the
+service name, port number, file path, etc.) and a state value drawn from the
+matching `*State` union.
+
+| Resource | Constructor | States |
+|---|---|---|
+| Service | `service : Text -> ServiceState -> Assertion` | `Running`, `Enabled` |
+| Package | `package : Text -> PackageState -> Assertion` | `Installed` |
+| Port | `port : Natural -> PortState -> Assertion` | `Listening`, `WithProtocol : Text` |
+| Command | `command : Text -> CommandState -> Assertion` | `ExitCode : Natural` |
+| File | `file : Text -> FileState -> Assertion` | `Exist`, `OwnedBy : Text`, `GroupedInto : Text`, `Mode : Natural`, `Contains : Text` |
+| User | `user : Text -> UserState -> Assertion` | `Exist`, `HasUid : Natural`, `BelongsToGroup : Text`, `HasHomeDirectory : Text`, `HasLoginShell : Text` |
+| Group | `group : Text -> GroupState -> Assertion` | `Exist`, `HasGid : Natural` |
+| Process | `process : Text -> ProcessState -> Assertion` | `Running`, `RunByUser : Text` |
+| Mount | `mount : Text -> MountState -> Assertion` | `Mounted`, `OnDevice : Text`, `OfFstype : Text` |
+| Interface | `interface : Text -> InterfaceState -> Assertion` | `Exist`, `HasSpeed : Natural`, `HasIpv4Address : Text` |
+| Kernel module | `kernelModule : Text -> KernelModuleState -> Assertion` | `Loaded` |
+| Bond | `bond : Text -> BondState -> Assertion` | `Exist`, `HasInterface : Text` |
+| Bridge | `bridge : Text -> BridgeState -> Assertion` | `Exist`, `HasInterface : Text` |
+| Default gateway (singleton) | `defaultGateway : DefaultGatewayState -> Assertion` | `HasIpaddress : Text`, `HasInterface : Text` |
+| Host | `host : Text -> HostState -> Assertion` | `Resolvable`, `Reachable`, `HasIpaddress : Text` |
+| iptables | `iptables : Text -> IptablesState -> Assertion` | `HasRule : Text` |
+| ip6tables | `ip6tables : Text -> Ip6tablesState -> Assertion` | `HasRule : Text` |
+| ipfilter | `ipfilter : Text -> IpfilterState -> Assertion` | `HasRule : Text` |
+| ipnat | `ipnat : Text -> IpnatState -> Assertion` | `HasRule : Text` |
+| Routing table (singleton) | `routingTable : RoutingTableState -> Assertion` | `HasEntry : { destination : Text, gateway : Text }` |
+| SELinux (singleton) | `selinux : SelinuxState -> Assertion` | `Enforcing`, `Permissive`, `Disabled` |
+| SELinux module | `selinuxModule : Text -> SelinuxModuleState -> Assertion` | `Enabled`, `Installed` |
+| Linux audit system (singleton) | `linuxAuditSystem : LinuxAuditSystemState -> Assertion` | `Running`, `Enabled` |
+| Linux kernel parameter | `linuxKernelParameter : Text -> LinuxKernelParameterState -> Assertion` | `HasValue : Text` |
+| Cgroup | `cgroup : Text -> CgroupState -> Assertion` | `HasParameter : { name : Text, value : Text }` |
+
+To express more than one state for the same resource (e.g. nginx must be both
+running and enabled), write two assertions with the same primary key — they
+are merged into a single `describe` block in the generated Ruby.
+
+To add a new resource, extend `dhall/Serverspec.dhall` with a smart
+constructor and a state type, then add one entry to `formatItLine` in
+`src/PanInfraSpec/Emit/Serverspec.hs` mapping each attribute key to its Ruby
+DSL line.

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,0 +1,25 @@
+# Loading inventory from Terraform state
+
+Instead of hand-writing `examples/inventory.dhall`, point at a
+`terraform.tfstate` JSON file:
+
+```sh
+cabal run paninfraspec-gen -- \
+  --from-terraform-state examples/terraform-state.json \
+  --plan                 examples/plan.dhall \
+  --target               serverspec \
+  --out                  /tmp/out
+```
+
+The Terraform adapter walks every `aws_instance` resource and applies the
+following tag conventions:
+
+| Field | Source | Fallback |
+|---|---|---|
+| `hostname` | `tags.Name` | `attributes.id`, then `<type>.<name>` |
+| `ip` | `attributes.private_ip` | `attributes.public_ip`, then `None` |
+| `role` | `tags.Role` | `"untagged"` |
+| `tags` | remaining tag *values* (Name & Role excluded) | `[]` |
+
+Other resource types (security groups, IAM, etc.) are skipped. Pass exactly
+one of `--inventory` or `--from-terraform-state`, not both.

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -1,9 +1,9 @@
 cabal-version:      3.0
 name:               paninfraspec
-version:            0.1.0.0
+version:            0.1.1.0
 synopsis:           Multi-input / multi-output compiler for infra specs (Phase 1: Serverspec)
 description:        Generates Serverspec Ruby files from per-backend Dhall preludes
-                    via a Generic Semantic AST. See specification.md.
+                    via a Generic Semantic AST.
 build-type:         Simple
 
 common deps

--- a/src/PanInfraSpec/CLI.hs
+++ b/src/PanInfraSpec/CLI.hs
@@ -32,13 +32,14 @@ import PanInfraSpec.SoT (toNodes)
 import PanInfraSpec.SoT.Terraform (TerraformStateFile (..))
 
 -- | Source of @[Node]@ data. The parser is built with @<|>@ so adding new
--- adapters in later phases stays additive (specification.md §6.2.1).
+-- adapters in later phases stays additive.
 --
 -- The CLI flag for 'FromTerraformState' is @--from-terraform-state PATH@
--- (single token). The spec sketch in §7.2 shows @--from terraform-state PATH@
--- (two tokens), but optparse-applicative's applicative parser cannot dispatch
--- on the value of a previously-parsed flag, so we collapse to a single
--- token. Each future adapter gets its own dedicated @--from-<adapter>@ flag.
+-- (single token). An earlier @--from terraform-state PATH@ (two-token) form
+-- was considered, but optparse-applicative's applicative parser cannot
+-- dispatch on the value of a previously-parsed flag, so we collapse to a
+-- single token. Each future adapter gets its own dedicated @--from-<adapter>@
+-- flag.
 data InventorySource
   = FromDhall          FilePath
   | FromTerraformState FilePath
@@ -188,8 +189,8 @@ run opts@Options{..} = do
                            Right outs -> writeAll optOut outs
 
 -- | Layer-1 check: the @--target@ flag must match the @targetBackend@ field
--- the plan file forwards from its imported per-backend Dhall prelude
--- (specification.md §6.2). Returning @Left@ here is mapped to exit 2 by 'die'.
+-- the plan file forwards from its imported per-backend Dhall prelude.
+-- Returning @Left@ here is mapped to exit 2 by 'die'.
 checkTargetMatches :: Text -> PlanFile -> Either Text ()
 checkTargetMatches t pf
   | t == pfTargetBackend pf = Right ()

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -19,8 +19,7 @@ loadInventory = Dhall.inputFile Dhall.auto
 
 -- | Load the plan file via Dhall and decode to a 'PlanFile' record. The
 -- record carries @targetBackend@ forwarded from the imported per-backend
--- prelude so the CLI can compare it against @--target@ (specification.md
--- §6.2).
+-- prelude so the CLI can compare it against @--target@.
 loadPlan :: FilePath -> IO PlanFile
 loadPlan = Dhall.inputFile Dhall.auto
 
@@ -30,7 +29,7 @@ knownBackends = ["serverspec"]
 
 -- | Allowed @aKind@ values per backend. Acts as the layer-2 defence against
 -- Smart Constructor 迂回 (a user hand-writing an Assertion record bypassing
--- the Dhall smart constructors). See specification.md §4.3.
+-- the Dhall smart constructors).
 backendAllowedKinds :: Text -> [Text]
 backendAllowedKinds = \case
   "serverspec" ->

--- a/src/PanInfraSpec/IR.hs
+++ b/src/PanInfraSpec/IR.hs
@@ -199,8 +199,7 @@ instance Dhall.FromDhall Mapping where
 
 -- | The whole loaded plan file. The @targetBackend@ field is forwarded from
 -- the per-backend Dhall prelude (e.g., @Serverspec.dhall@) and lets the CLI
--- assert that @--target@ matches the prelude the user actually imported
--- (specification.md §6.2).
+-- assert that @--target@ matches the prelude the user actually imported.
 data PlanFile = PlanFile
   { pfTargetBackend :: Text
   , pfMappings      :: [Mapping]


### PR DESCRIPTION
## Summary
- Move the Resource catalogue (26-row table) into `docs/resources.md` and the Terraform inventory loader walkthrough into `docs/terraform.md`; the README keeps a short summary plus a link for each. README shrinks from 266 to 211 lines.
- Remove every reference to `specification.md` (cabal description, `dhall/Inventory.dhall`, `dhall/Plan.dhall`, `dhall/Serverspec.dhall`, and source comments in `CLI.hs`, `Dhall.hs`, `IR.hs`) since the file is not present in the repo.
- Bump `paninfraspec` to `0.1.1.0` to mark the user-visible doc reorganisation.

## Test plan
- [ ] `cabal build` succeeds (comments-only changes under `-Werror`).
- [ ] `grep -rn 'specification\.md' README.md docs/ paninfraspec.cabal dhall/ src/ app/ test/` returns no matches.
- [ ] Open `docs/resources.md` on GitHub and confirm the 26-row table renders correctly and the `../dhall/Serverspec.dhall` link resolves.
- [ ] Open `docs/terraform.md` on GitHub and confirm the tag-conventions table renders.
- [ ] Re-run the Quickstart in the README to confirm the trimmed Terraform / Resource catalogue sections still convey enough to follow the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)