### PR TITLE
Support per-host dynamic expected values via customAttributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ in  [ { hostname = "web01", ip = Some "10.0.1.10", role = "Web",       tags = [ 
     ] : List I.Node
 ```
 
-Each node has four fields:
+Each node has five fields:
 
 | Field | Meaning |
 |---|---|
@@ -67,6 +67,7 @@ Each node has four fields:
 | `ip` | Optional. Recorded for your own reference; transport is configured via `TARGET_HOST` at run time. |
 | `role` | Free-form text. Selectors target nodes by role. |
 | `tags` | Free-form labels. A node can carry any number; selectors can target any one. |
+| `customAttributes` | List of `{ name, command }` pairs. Each one is run on the host at spec time and bound to a Ruby variable so plans can compare against per-host dynamic values. See [Per-host dynamic expected values](#per-host-dynamic-expected-values). Pass `[] : List I.CustomAttribute` if you don't need any. |
 
 ## Writing a plan
 
@@ -183,6 +184,83 @@ constructor takes a primary key plus a state value drawn from a typed union.
 
 See [`docs/resources.md`](./docs/resources.md) for the full table of
 constructors, their state unions, and how to add a new resource.
+
+## Per-host dynamic expected values
+
+Some assertions only make sense relative to a per-host runtime value — for
+example "MySQL's `innodb_buffer_pool_size` must be 70-80% of the host's total
+RAM". You can express this without falling back to raw shell by combining
+`Inventory.customAttributes` with the `CompareExpr` state on `mysql_config`,
+`php_config`, and `x509_certificate`.
+
+**Step 1: declare the per-host command in the inventory.**
+
+```dhall
+{ hostname         = "db01"
+, ip               = Some "10.0.2.10"
+, role             = "DBPrimary"
+, tags             = [ "metrics" ]
+, customAttributes =
+    [ { name    = "total_ram_kb"
+      , command = "awk '/MemTotal/ {print $2}' /proc/meminfo"
+      }
+    ]
+}
+```
+
+The generator binds each `customAttribute` to a Ruby variable at the top of
+that host's spec file:
+
+```ruby
+require 'spec_helper'
+
+paninfraspec_total_ram_kb = Specinfra.backend.run_command("awk '/MemTotal/ {print $2}' /proc/meminfo").stdout.strip
+```
+
+`name` must be a valid Ruby local-variable identifier
+(`^[a-z_][a-zA-Z0-9_]*$`); duplicates within the same host and empty
+names/commands are rejected at generate time.
+
+**Step 2: reference it from the plan with `expand_attr`.**
+
+```dhall
+let Spec = ../dhall/Serverspec.dhall
+
+in  Spec.mysqlConfig "innodb_buffer_pool_size"
+      ( Spec.MysqlConfigState.CompareExpr
+          { op    = Spec.CompareOp.Gt
+          , value =
+              Spec.expand_attr "total_ram_kb" ++ ".to_i * 1024 * 70 / 100"
+          }
+      )
+```
+
+`Spec.expand_attr "<name>"` is the only place the `paninfraspec_` prefix
+appears — the generator owns it and may rename it; your plans never need to
+hard-code the prefix string. The generated assertion is:
+
+```ruby
+describe mysql_config('innodb_buffer_pool_size') do
+  its(:value) { should be > paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100 }
+end
+```
+
+`CompareExpr` is available on `MysqlConfigState`, `PhpConfigState`, and
+`X509CertificateState` (as `ValidityInDaysCompareExpr`). The `value : Text`
+field is emitted **as bare Ruby**, so you can chain `.to_i`/`.to_f` and use
+arithmetic operators. The existing `Compare` (`Natural`) variants stay
+available for static thresholds.
+
+**Escape hatch.** If you need a Ruby expression in a context other than the
+three `*ConfigState` types, use `AttrLeaf.ALRubyExpr` directly. That is the
+underlying constructor; everything else (`expand_attr`, `CompareExpr`) is
+sugar on top.
+
+**Out of scope.** PanInfraSpec does not statically check that a
+`paninfraspec_<name>` token in a `value` string actually resolves to a
+declared `customAttribute` — an undefined reference fails at spec runtime
+with `NameError`. Use `expand_attr` (rather than hand-writing the prefix) to
+keep typos visible in code review.
 
 ## How it works
 

--- a/dhall/Inventory.dhall
+++ b/dhall/Inventory.dhall
@@ -3,13 +3,20 @@
 
 let Role = Text  -- organisations have different role vocabularies; keep as Text wrapper
 
-let Node =
-      { hostname : Text
-      , ip       : Optional Text
-      , role     : Role
-      , tags     : List Text
+let CustomAttribute =
+      { name    : Text
+      , command : Text
       }
 
-in  { Role = Role
-    , Node = Node
+let Node =
+      { hostname         : Text
+      , ip               : Optional Text
+      , role             : Role
+      , tags             : List Text
+      , customAttributes : List CustomAttribute
+      }
+
+in  { Role             = Role
+    , CustomAttribute  = CustomAttribute
+    , Node             = Node
     }

--- a/dhall/Serverspec.dhall
+++ b/dhall/Serverspec.dhall
@@ -6,11 +6,12 @@
 let CompareOp = < Lt | Le | Gt | Ge | Eq | Match >
 
 let AttrLeaf =
-      < ALText   : Text
-      | ALNat    : Natural
-      | ALBool   : Bool
-      | ALSymbol : Text
-      | ALRegex  : Text
+      < ALText     : Text
+      | ALNat      : Natural
+      | ALBool     : Bool
+      | ALSymbol   : Text
+      | ALRegex    : Text
+      | ALRubyExpr : Text
       >
 
 let AttrValue =
@@ -151,7 +152,9 @@ let CronState =
       | HasEntryAsUser : { entry : Text, user : Text }
       >
 let X509CertificateState =
-      < ValidityInDaysCompare : { op : CompareOp, value : Natural } >
+      < ValidityInDaysCompare     : { op : CompareOp, value : Natural }
+      | ValidityInDaysCompareExpr : { op : CompareOp, value : Text }
+      >
 let WindowsRegistryKeyState =
       < HasProperty      : { name : Text, propertyType : Text }
       | HasPropertyValue : { name : Text, propertyType : Text, value : Natural }
@@ -180,16 +183,18 @@ let IisWebsiteState =
       >
 
 let MysqlConfigState =
-      < EqText  : Text
-      | EqNat   : Natural
-      | Compare : { op : CompareOp, value : Natural }
+      < EqText      : Text
+      | EqNat       : Natural
+      | Compare     : { op : CompareOp, value : Natural }
+      | CompareExpr : { op : CompareOp, value : Text }
       >
 
 let PhpConfigState =
-      < EqText  : Text
-      | EqNat   : Natural
-      | Compare : { op : CompareOp, value : Natural }
-      | Match   : Text
+      < EqText      : Text
+      | EqNat       : Natural
+      | Compare     : { op : CompareOp, value : Natural }
+      | CompareExpr : { op : CompareOp, value : Text }
+      | Match       : Text
       >
 
 let X509PrivateKeyState =
@@ -629,6 +634,13 @@ let x509CertificateStateAttrs =
                       AttrValue.AVCompare
                         { op = c.op, value = AttrLeaf.ALNat c.value }
                   }
+          , ValidityInDaysCompareExpr =
+              \(c : { op : CompareOp, value : Text }) ->
+                toMap
+                  { validity_in_days =
+                      AttrValue.AVCompare
+                        { op = c.op, value = AttrLeaf.ALRubyExpr c.value }
+                  }
           }
           s
 
@@ -737,6 +749,13 @@ let mysqlConfigStateAttrs =
                       AttrValue.AVCompare
                         { op = c.op, value = AttrLeaf.ALNat c.value }
                   }
+          , CompareExpr =
+              \(c : { op : CompareOp, value : Text }) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = c.op, value = AttrLeaf.ALRubyExpr c.value }
+                  }
           }
           s
 
@@ -763,6 +782,13 @@ let phpConfigStateAttrs =
                   { value =
                       AttrValue.AVCompare
                         { op = c.op, value = AttrLeaf.ALNat c.value }
+                  }
+          , CompareExpr =
+              \(c : { op : CompareOp, value : Text }) ->
+                toMap
+                  { value =
+                      AttrValue.AVCompare
+                        { op = c.op, value = AttrLeaf.ALRubyExpr c.value }
                   }
           , Match =
               \(p : Text) ->
@@ -1224,6 +1250,16 @@ let dockerImage
         , attrs = dockerImageStateAttrs s
         }
 
+-- | Expand an Inventory custom-attribute @name@ into the Ruby variable name
+-- the emitter binds at the top of the generated spec file. Plans that need
+-- to reference a per-host dynamic value should write
+-- @expand_attr "mem_total_bytes"@ instead of hard-coding
+-- @"paninfraspec_mem_total_bytes"@: the prefix is owned by the generator and
+-- may change.
+let expand_attr
+    : Text -> Text
+    = \(name : Text) -> "paninfraspec_" ++ name
+
 in  { AttrValue         = AttrValue
     , AttrLeaf          = AttrLeaf
     , CompareOp         = CompareOp
@@ -1313,5 +1349,7 @@ in  { AttrValue         = AttrValue
     , zfs                   = zfs
     , dockerContainer       = dockerContainer
     , dockerImage           = dockerImage
+    -- Custom-attribute references (Inventory.customAttributes)
+    , expand_attr          = expand_attr
     , targetBackend     = "serverspec"
     }

--- a/examples/inventory.dhall
+++ b/examples/inventory.dhall
@@ -3,20 +3,31 @@
 
 let I = ../dhall/Inventory.dhall
 
-in  [ { hostname = "web01"
-      , ip = Some "10.0.1.10"
-      , role = "Web"
-      , tags = [ "frontend", "metrics" ]
+in  [ { hostname         = "web01"
+      , ip               = Some "10.0.1.10"
+      , role             = "Web"
+      , tags             = [ "frontend", "metrics" ]
+      , customAttributes = [] : List I.CustomAttribute
       }
-    , { hostname = "web02"
-      , ip = Some "10.0.1.11"
-      , role = "Web"
-      , tags = [ "frontend" ]
+    , { hostname         = "web02"
+      , ip               = Some "10.0.1.11"
+      , role             = "Web"
+      , tags             = [ "frontend" ]
+      , customAttributes = [] : List I.CustomAttribute
       }
-    , { hostname = "db01"
-      , ip = None Text
-      , role = "DBPrimary"
-      , tags = [ "metrics" ]
+    , { hostname         = "db01"
+      , ip               = None Text
+      , role             = "DBPrimary"
+      , tags             = [ "metrics" ]
+      , customAttributes =
+          -- Read /proc/meminfo on the target so the plan's mysql_config
+          -- CompareExpr can size innodb_buffer_pool_size relative to
+          -- this host's actual RAM. Bound as `paninfraspec_total_ram_kb`
+          -- in the generated db01_spec.rb.
+          [ { name    = "total_ram_kb"
+            , command = "awk '/MemTotal/ {print \$2}' /proc/meminfo"
+            }
+          ]
       }
     ]
   : List I.Node

--- a/examples/plan.dhall
+++ b/examples/plan.dhall
@@ -23,8 +23,31 @@ let nginxSpec
       , Spec.process "nginx" Spec.ProcessState.Running
       ]
 
+-- DBPrimary nodes: assert that MySQL's innodb_buffer_pool_size is at least
+-- 70% of the host's total RAM. The threshold is per-host and resolved on the
+-- target via the customAttribute "total_ram_kb" declared in
+-- examples/inventory.dhall; `Spec.expand_attr` keeps plans free of the
+-- generator's `paninfraspec_` prefix.
+--
+-- Note: a single primaryKey can carry only one bound on `value`, so this
+-- example expresses the lower bound only. To enforce "between 70% and 80%",
+-- combine both checks in the host-side script and assert ExitCode 0 on a
+-- `command` instead.
+let mysqlSpec
+    : List Spec.Assertion
+    = [ Spec.mysqlConfig "innodb_buffer_pool_size"
+          ( Spec.MysqlConfigState.CompareExpr
+              { op    = Spec.CompareOp.Ge
+              , value =
+                  Spec.expand_attr "total_ram_kb"
+                    ++ ".to_i * 1024 * 70 / 100"
+              }
+          )
+      ]
+
 in  Plan.make Spec.targetBackend
       [ Plan.onAll baseSpec
       , Plan.forRole "Web" nginxSpec
+      , Plan.forRole "DBPrimary" mysqlSpec
       , Plan.forTag "metrics" [ Spec.port 9090 Spec.PortState.Listening ]
       ]

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               paninfraspec
-version:            0.1.1.0
+version:            0.2.0.0
 synopsis:           Multi-input / multi-output compiler for infra specs (Phase 1: Serverspec)
 description:        Generates Serverspec Ruby files from per-backend Dhall preludes
                     via a Generic Semantic AST.

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -73,6 +73,7 @@ test-suite paninfraspec-test
   other-modules:
       Unit.ValidateTest
     , Unit.LayoutTest
+    , Unit.EmitCustomAttributesTest
     , Roundtrip.DhallEncodingTest
     , Property.EmitTest
     , Synth.HundredHostsTest

--- a/src/PanInfraSpec/DumpPlan.hs
+++ b/src/PanInfraSpec/DumpPlan.hs
@@ -63,11 +63,12 @@ renderValue = \case
 
 renderLeaf :: AttrLeaf -> Text
 renderLeaf = \case
-  ALText   t -> "\"" <> t <> "\""
-  ALNat    n -> tshow n
-  ALBool   b -> if b then "True" else "False"
-  ALSymbol s -> ":" <> s
-  ALRegex  p -> "/" <> p <> "/"
+  ALText     t -> "\"" <> t <> "\""
+  ALNat      n -> tshow n
+  ALBool     b -> if b then "True" else "False"
+  ALSymbol   s -> ":" <> s
+  ALRegex    p -> "/" <> p <> "/"
+  ALRubyExpr e -> "{ruby:" <> e <> "}"
 
 renderOp :: CompareOp -> Text
 renderOp = \case

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -6,6 +6,7 @@ module PanInfraSpec.Emit.Serverspec
   ) where
 
 import Control.Monad (foldM, forM_, unless, when)
+import Data.Char (isAsciiLower, isAsciiUpper, isDigit)
 import Data.Function (on)
 import Data.List (groupBy, sortOn)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -564,11 +565,12 @@ kindToRubyResource = \case
 -- | Render a single 'AttrLeaf' as a Ruby literal.
 renderLeafRuby :: AttrLeaf -> Doc ann
 renderLeafRuby = \case
-  ALText   t -> rubyString t
-  ALNat    n -> pretty n
-  ALBool   b -> if b then "true" else "false"
-  ALSymbol s -> ":" <> pretty s
-  ALRegex  p -> "/" <> pretty p <> "/"
+  ALText     t -> rubyString t
+  ALNat      n -> pretty n
+  ALBool     b -> if b then "true" else "false"
+  ALSymbol   s -> ":" <> pretty s
+  ALRegex    p -> "/" <> pretty p <> "/"
+  ALRubyExpr e -> pretty e
 
 -- | Render a record as @:k => v, :k => v@ (Ruby keyword-arg syntax). Used
 -- by @host.be_reachable.with@, @routing_table.have_entry@, etc.
@@ -874,18 +876,74 @@ formatGroup (Assertion k pk attrs0) = do
   let body = vsep (renderAttrs k attrs)
   pure $ vsep [header, indent 2 body, "end"]
 
+-- | Validate the @customAttributes@ list of a 'Node' before emitting any
+-- @paninfraspec_<name> = ...@ preamble lines. Rejects:
+--
+--   * empty names or empty commands (both would produce broken Ruby);
+--   * names that are not valid Ruby local-variable identifiers
+--     (regex equivalent: @^[a-z_][a-zA-Z0-9_]*$@) — anything else would make
+--     the generated @.rb@ file fail with @SyntaxError@ at runtime;
+--   * duplicate names within the same node.
+--
+-- Returns the input list unchanged on success so callers can keep using the
+-- declaration order.
+validateCustomAttributes :: [CustomAttribute] -> Either Text [CustomAttribute]
+validateCustomAttributes cas = do
+  forM_ cas $ \ca -> do
+    when (T.null (caName ca)) $
+      Left "customAttribute name must be non-empty"
+    when (T.null (caCommand ca)) $
+      Left ("customAttribute command must be non-empty for: " <> caName ca)
+    unless (isValidRubyLocal (caName ca)) $
+      Left ("customAttribute name must be a valid Ruby local variable identifier: "
+              <> caName ca)
+  let names = map caName cas
+      seen  = foldr collect (Right Set.empty) names
+  case seen of
+    Left dup -> Left ("duplicate customAttribute name: " <> dup)
+    Right _  -> Right cas
+  where
+    collect _ (Left e)        = Left e
+    collect n (Right s)
+      | n `Set.member` s = Left n
+      | otherwise        = Right (Set.insert n s)
+
+    isValidRubyLocal :: Text -> Bool
+    isValidRubyLocal t = case T.uncons t of
+      Nothing      -> False
+      Just (c, cs) ->
+        (isAsciiLower c || c == '_')
+          && T.all isIdentTail cs
+      where
+        isIdentTail c = isAsciiLower c || isAsciiUpper c || isDigit c || c == '_'
+
+-- | Render the preamble block placed between @require 'spec_helper'@ and the
+-- first @describe@: one Ruby variable assignment per validated
+-- 'CustomAttribute'.
+renderCustomAttributePreamble :: [CustomAttribute] -> Doc ann
+renderCustomAttributePreamble cas = vsep
+  [ "paninfraspec_" <> pretty (caName ca)
+      <+> "=" <+> "Specinfra.backend.run_command(" <> rubyString (caCommand ca) <> ").stdout.strip"
+  | ca <- cas
+  ]
+
 -- | Render a 'Job' as a @(filename, content)@ pair. The filename comes from
 -- the Layout's 'lSpecPath' applied to the node, then validated to make sure
 -- the user's Dhall function did not produce something that would write
 -- outside the @--out@ directory.
 formatJob :: Layout -> Job -> Either Text (FilePath, Text)
 formatJob layout (Job node assertions) = do
-  validated <- traverse validateAssertion assertions
-  merged    <- traverse mergeGroup (groupAssertions validated)
-  blocks    <- traverse formatGroup merged
-  filename  <- validateLayoutPath (T.unpack (lSpecPath layout node))
+  validatedCAs <- validateCustomAttributes (customAttributes node)
+  validated    <- traverse validateAssertion assertions
+  merged       <- traverse mergeGroup (groupAssertions validated)
+  blocks       <- traverse formatGroup merged
+  filename     <- validateLayoutPath (T.unpack (lSpecPath layout node))
   let docText d = renderStrict (PP.layoutPretty PP.defaultLayoutOptions d)
-      body      = T.intercalate "\n\n" ("require 'spec_helper'" : map docText blocks)
+      preambleLines
+        | null validatedCAs = []
+        | otherwise         = [docText (renderCustomAttributePreamble validatedCAs)]
+      body = T.intercalate "\n\n"
+               ("require 'spec_helper'" : preambleLines ++ map docText blocks)
   pure (filename, body <> "\n")
 
 -- | Static @spec_helper.rb@ produced alongside each output set. Uses the

--- a/src/PanInfraSpec/IR.hs
+++ b/src/PanInfraSpec/IR.hs
@@ -1,5 +1,6 @@
 module PanInfraSpec.IR
   ( Role (..)
+  , CustomAttribute (..)
   , Node (..)
   , CompareOp (..)
   , AttrLeaf (..)
@@ -11,6 +12,7 @@ module PanInfraSpec.IR
   , Job (..)
   , ExecutionPlan (..)
   , roleEncoder
+  , customAttributeEncoder
   , nodeEncoder
   ) where
 
@@ -30,22 +32,42 @@ newtype Role = Role { unRole :: Text }
   deriving stock   (Generic)
   deriving newtype (Show, Eq, Ord, IsString, Dhall.FromDhall)
 
+-- | A per-host shell command whose stdout becomes a Ruby variable bound at
+-- the top of the generated spec file (as @paninfraspec_<caName>@). Plans can
+-- then reference that value via 'AttrLeaf.ALRubyExpr', enabling
+-- host-dependent expected values (e.g., "innodb_buffer_pool_size must be at
+-- least 70% of the host's total RAM"). Mirrors the Dhall record
+-- @{ name : Text, command : Text }@ in @dhall/Inventory.dhall@.
+data CustomAttribute = CustomAttribute
+  { caName    :: Text
+  , caCommand :: Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall CustomAttribute where
+  autoWith _ = Dhall.record $
+    CustomAttribute
+      <$> Dhall.field "name"    Dhall.auto
+      <*> Dhall.field "command" Dhall.auto
+
 -- | One inventory entry. Mirrors @dhall/Inventory.dhall@'s @Node@.
 data Node = Node
-  { hostname :: Text
-  , ip       :: Maybe Text
-  , role     :: Role
-  , tags     :: [Text]
+  { hostname         :: Text
+  , ip               :: Maybe Text
+  , role             :: Role
+  , tags             :: [Text]
+  , customAttributes :: [CustomAttribute]
   }
   deriving stock (Show, Eq, Generic)
 
 instance Dhall.FromDhall Node where
   autoWith _ = Dhall.record $
     Node
-      <$> Dhall.field "hostname" Dhall.auto
-      <*> Dhall.field "ip"       Dhall.auto
-      <*> Dhall.field "role"     Dhall.auto
-      <*> Dhall.field "tags"     Dhall.auto
+      <$> Dhall.field "hostname"         Dhall.auto
+      <*> Dhall.field "ip"               Dhall.auto
+      <*> Dhall.field "role"             Dhall.auto
+      <*> Dhall.field "tags"             Dhall.auto
+      <*> Dhall.field "customAttributes" Dhall.auto
 
 -- | Encoder for 'Role'. Wraps Text via the Role newtype unwrap. Needed so a
 -- Dhall function value @\\(n : Inventory.Node) -> ...@ can be applied
@@ -53,6 +75,22 @@ instance Dhall.FromDhall Node where
 -- before evaluating the user's function. See 'PanInfraSpec.Layout'.
 roleEncoder :: Dhall.Encoder Role
 roleEncoder = contramap unRole Dhall.inject
+
+-- | Encoder for 'CustomAttribute'. Mirrors the Dhall record
+-- @{ name : Text, command : Text }@ so a user-written
+-- @\\(n : Inventory.Node) -> ...@ can reach @n.customAttributes@ during
+-- Layout evaluation if it ever wants to.
+customAttributeEncoder :: Dhall.Encoder CustomAttribute
+customAttributeEncoder = Dhall.recordEncoder $
+  splay >$< (Dhall.encodeFieldWith "name"    Dhall.inject
+       `divided`  Dhall.encodeFieldWith "command" Dhall.inject)
+  where
+    splay c = (caName c, caCommand c)
+
+-- | 'ToDhall' instance for 'CustomAttribute' lets @Dhall.inject@ derive an
+-- encoder for @[CustomAttribute]@ when building 'nodeEncoder'.
+instance Dhall.ToDhall CustomAttribute where
+  injectWith _ = customAttributeEncoder
 
 -- | Encoder for 'Node'. The field set and types must match
 -- @dhall/Inventory.dhall@'s @Node@ exactly, otherwise the user's
@@ -66,9 +104,10 @@ nodeEncoder = Dhall.recordEncoder $
   splay >$< (Dhall.encodeFieldWith "hostname" Dhall.inject
        `divided` (Dhall.encodeFieldWith "ip" Dhall.inject
        `divided` (Dhall.encodeFieldWith "role" roleEncoder
-       `divided`  Dhall.encodeFieldWith "tags" Dhall.inject)))
+       `divided` (Dhall.encodeFieldWith "tags" Dhall.inject
+       `divided`  Dhall.encodeFieldWith "customAttributes" Dhall.inject))))
   where
-    splay n = (hostname n, (ip n, (role n, tags n)))
+    splay n = (hostname n, (ip n, (role n, (tags n, customAttributes n))))
 
 -- | Comparison operator for 'AVCompare'. Mirrors the Dhall union
 -- @< Lt | Le | Gt | Ge | Eq | Match >@. Used for matchers like
@@ -91,20 +130,27 @@ instance Dhall.FromDhall CompareOp where
 -- nested element type is a separate, non-recursive union (the same trick
 -- used for 'Selector' boolean composition).
 data AttrLeaf
-  = ALText   Text
-  | ALNat    Natural
-  | ALBool   Bool
-  | ALSymbol Text
-  | ALRegex  Text   -- ^ Ruby regex literal payload (without surrounding @/.../@).
+  = ALText     Text
+  | ALNat      Natural
+  | ALBool     Bool
+  | ALSymbol   Text
+  | ALRegex    Text   -- ^ Ruby regex literal payload (without surrounding @/.../@).
+  | ALRubyExpr Text   -- ^ Bare Ruby expression. Emitted unquoted so the value
+                      -- can flow into a matcher that compares against a Ruby
+                      -- variable or arithmetic expression (e.g.
+                      -- @paninfraspec_total_ram_kb.to_i * 1024 * 70 \/ 100@).
+                      -- Unlike 'ALText', no escaping or surrounding quotes
+                      -- are added — the user is asserting "this is Ruby".
   deriving stock (Show, Eq, Generic)
 
 instance Dhall.FromDhall AttrLeaf where
   autoWith _ = Dhall.union
-    (  (ALText   <$> Dhall.constructor "ALText"   Dhall.auto)
-    <> (ALNat    <$> Dhall.constructor "ALNat"    Dhall.auto)
-    <> (ALBool   <$> Dhall.constructor "ALBool"   Dhall.auto)
-    <> (ALSymbol <$> Dhall.constructor "ALSymbol" Dhall.auto)
-    <> (ALRegex  <$> Dhall.constructor "ALRegex"  Dhall.auto)
+    (  (ALText     <$> Dhall.constructor "ALText"     Dhall.auto)
+    <> (ALNat      <$> Dhall.constructor "ALNat"      Dhall.auto)
+    <> (ALBool     <$> Dhall.constructor "ALBool"     Dhall.auto)
+    <> (ALSymbol   <$> Dhall.constructor "ALSymbol"   Dhall.auto)
+    <> (ALRegex    <$> Dhall.constructor "ALRegex"    Dhall.auto)
+    <> (ALRubyExpr <$> Dhall.constructor "ALRubyExpr" Dhall.auto)
     )
 
 -- | Attribute value carried inside an 'Assertion'. Mirrors the Dhall union

--- a/src/PanInfraSpec/SoT/Terraform.hs
+++ b/src/PanInfraSpec/SoT/Terraform.hs
@@ -114,10 +114,11 @@ instanceToNode r (TfInstance attrs) = do
         ]
   hn <- mHost
   pure Node
-    { hostname = hn
-    , ip       = mIp
-    , role     = Role roleT
-    , tags     = restTags
+    { hostname         = hn
+    , ip               = mIp
+    , role             = Role roleT
+    , tags             = restTags
+    , customAttributes = []
     }
 
 -- | Read a Text-typed JSON attribute, returning 'Nothing' if missing or null.

--- a/test/Golden/by_role/inventory.dhall
+++ b/test/Golden/by_role/inventory.dhall
@@ -1,14 +1,16 @@
 let I = ../../../dhall/Inventory.dhall
 
-in  [ { hostname = "web01"
-      , ip       = Some "10.0.1.10"
-      , role     = "Web"
-      , tags     = [ "frontend" ]
+in  [ { hostname         = "web01"
+      , ip               = Some "10.0.1.10"
+      , role             = "Web"
+      , tags             = [ "frontend" ]
+      , customAttributes = [] : List I.CustomAttribute
       }
-    , { hostname = "db01"
-      , ip       = None Text
-      , role     = "DBPrimary"
-      , tags     = [ "metrics" ]
+    , { hostname         = "db01"
+      , ip               = None Text
+      , role             = "DBPrimary"
+      , tags             = [ "metrics" ]
+      , customAttributes = [] : List I.CustomAttribute
       }
     ]
   : List I.Node

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -1,5 +1,9 @@
 require 'spec_helper'
 
+paninfraspec_total_ram_kb = Specinfra.backend.run_command('awk \'/MemTotal/ {print $2}\' /proc/meminfo').stdout.strip
+paninfraspec_max_mem_mb = Specinfra.backend.run_command('echo 256').stdout.strip
+paninfraspec_min_cert_days = Specinfra.backend.run_command('echo 30').stdout.strip
+
 describe bond('bond0') do
   it { should exist }
   it { should have_interface 'eth0' }
@@ -180,6 +184,10 @@ describe mysql_config('innodb-buffer-pool-size') do
   its(:value) { should be > 100000000 }
 end
 
+describe mysql_config('innodb_buffer_pool_size_bytes') do
+  its(:value) { should be > paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100 }
+end
+
 describe mysql_config('socket') do
   its(:value) { should eq '/tmp/mysql.sock' }
 end
@@ -198,6 +206,10 @@ end
 
 describe php_config('mbstring.http_output_conv_mimetypes') do
   its(:value) { should match /application/ }
+end
+
+describe php_config('memory_limit_mb') do
+  its(:value) { should be <= paninfraspec_max_mem_mb.to_i }
 end
 
 describe php_config('session.cache_expire') do
@@ -264,6 +276,10 @@ end
 
 describe x509_certificate('/etc/ssl/cert.pem') do
   its(:validity_in_days) { should be > 30 }
+end
+
+describe x509_certificate('/etc/ssl/server.crt') do
+  its(:validity_in_days) { should be >= paninfraspec_min_cert_days.to_i }
 end
 
 describe x509_private_key('/my/private/server-key.pem') do

--- a/test/Golden/inventory.dhall
+++ b/test/Golden/inventory.dhall
@@ -1,9 +1,14 @@
 let I = ../../dhall/Inventory.dhall
 
-in  [ { hostname = "web01"
-      , ip = Some "10.0.1.10"
-      , role = "Web"
-      , tags = [ "frontend", "metrics" ]
+in  [ { hostname         = "web01"
+      , ip               = Some "10.0.1.10"
+      , role             = "Web"
+      , tags             = [ "frontend", "metrics" ]
+      , customAttributes =
+          [ { name = "total_ram_kb",   command = "awk '/MemTotal/ {print \$2}' /proc/meminfo" }
+          , { name = "max_mem_mb",     command = "echo 256" }
+          , { name = "min_cert_days",  command = "echo 30" }
+          ]
       }
     ]
   : List I.Node

--- a/test/Golden/plan.dhall
+++ b/test/Golden/plan.dhall
@@ -85,6 +85,13 @@ in  Plan.make Spec.targetBackend
               ( Spec.X509CertificateState.ValidityInDaysCompare
                   { op = Spec.CompareOp.Gt, value = 30 }
               )
+          -- ValidityInDaysCompareExpr: dynamic threshold via expand_attr.
+          , Spec.x509Certificate "/etc/ssl/server.crt"
+              ( Spec.X509CertificateState.ValidityInDaysCompareExpr
+                  { op    = Spec.CompareOp.Ge
+                  , value = Spec.expand_attr "min_cert_days" ++ ".to_i"
+                  }
+              )
           , Spec.windowsRegistryKey "HKEY_LOCAL_MACHINE\\Some\\Key"
               ( Spec.WindowsRegistryKeyState.HasProperty
                   { name = "NumProperty", propertyType = "type_dword" }
@@ -155,10 +162,27 @@ in  Plan.make Spec.targetBackend
               ( Spec.MysqlConfigState.Compare
                   { op = Spec.CompareOp.Gt, value = 100000000 }
               )
+          -- CompareExpr: per-host dynamic threshold via customAttributes.
+          -- expand_attr "total_ram_kb" -> "paninfraspec_total_ram_kb".
+          , Spec.mysqlConfig "innodb_buffer_pool_size_bytes"
+              ( Spec.MysqlConfigState.CompareExpr
+                  { op    = Spec.CompareOp.Gt
+                  , value =
+                      Spec.expand_attr "total_ram_kb"
+                        ++ ".to_i * 1024 * 70 / 100"
+                  }
+              )
           , Spec.mysqlConfig "socket"
               (Spec.MysqlConfigState.EqText "/tmp/mysql.sock")
           , Spec.phpConfig "default_mimetype"
               (Spec.PhpConfigState.EqText "text/html")
+          -- CompareExpr for php_config (uses expand_attr "max_mem_mb").
+          , Spec.phpConfig "memory_limit_mb"
+              ( Spec.PhpConfigState.CompareExpr
+                  { op    = Spec.CompareOp.Le
+                  , value = Spec.expand_attr "max_mem_mb" ++ ".to_i"
+                  }
+              )
           , Spec.phpConfig "session.cache_expire"
               (Spec.PhpConfigState.EqNat 180)
           , Spec.phpConfig "mbstring.http_output_conv_mimetypes"

--- a/test/Property/EmitTest.hs
+++ b/test/Property/EmitTest.hs
@@ -21,10 +21,11 @@ tests = testGroup "property"
 
 dummyNode :: Node
 dummyNode = Node
-  { hostname = "synth"
-  , ip       = Nothing
-  , role     = Role "synth"
-  , tags     = []
+  { hostname         = "synth"
+  , ip               = Nothing
+  , role             = Role "synth"
+  , tags             = []
+  , customAttributes = []
   }
 
 -- | Pick one schema-allowed @(kind, attrKey, AttrTag)@ triple. Wildcard kinds

--- a/test/Roundtrip/DhallEncodingTest.hs
+++ b/test/Roundtrip/DhallEncodingTest.hs
@@ -14,13 +14,13 @@ attrValueU :: Text
 attrValueU =
   "< AVText : Text | AVNat : Natural | AVBool : Bool \
   \| AVSymbol : Text \
-  \| AVList : List < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > \
-  \| AVRecord : List { mapKey : Text, mapValue : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > } \
-  \| AVCompare : { op : < Lt | Le | Gt | Ge | Eq | Match >, value : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text > } \
+  \| AVList : List < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text | ALRubyExpr : Text > \
+  \| AVRecord : List { mapKey : Text, mapValue : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text | ALRubyExpr : Text > } \
+  \| AVCompare : { op : < Lt | Le | Gt | Ge | Eq | Match >, value : < ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text | ALRubyExpr : Text > } \
   \>"
 
 attrLeafU :: Text
-attrLeafU = "< ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text >"
+attrLeafU = "< ALText : Text | ALNat : Natural | ALBool : Bool | ALSymbol : Text | ALRegex : Text | ALRubyExpr : Text >"
 
 compareOpU :: Text
 compareOpU = "< Lt | Le | Gt | Ge | Eq | Match >"
@@ -64,6 +64,21 @@ tests = testGroup "Dhall round-trip"
       )
   , testCase "CompareOp.Gt"      (decodes ("(" <> compareOpU <> ").Gt") OpGt)
   , testCase "AttrLeaf.ALSymbol" (decodes ("(" <> attrLeafU <> ").ALSymbol \"foo\"") (ALSymbol "foo"))
+  , testCase "AttrLeaf.ALRubyExpr"
+      (decodes ("(" <> attrLeafU <> ").ALRubyExpr \"x.to_i * 2\"") (ALRubyExpr "x.to_i * 2"))
+  , testCase "AttrValue.AVCompare with ALRubyExpr"
+      (decodes
+        ("(" <> attrValueU <> ").AVCompare \
+         \{ op = (" <> compareOpU <> ").Gt \
+         \, value = (" <> attrLeafU <> ").ALRubyExpr \"paninfraspec_x.to_i\" \
+         \}")
+        (AVCompare OpGt (ALRubyExpr "paninfraspec_x.to_i"))
+      )
+  , testCase "CustomAttribute round-trip"
+      (decodes
+        "{ name = \"total_ram_kb\", command = \"awk '/MemTotal/' /proc/meminfo\" }"
+        (CustomAttribute "total_ram_kb" "awk '/MemTotal/' /proc/meminfo")
+      )
   , testCase "Selector.SelAll"   (decodes "(< SelAll | SelRole : Text | SelTag : Text | SelHost : Text >).SelAll"   SelAll)
   , testCase "Selector.SelRole"  (decodes "(< SelAll | SelRole : Text | SelTag : Text | SelHost : Text >).SelRole \"Web\"" (SelRole (Role "Web")))
   , testCase "Assertion record"
@@ -74,17 +89,17 @@ tests = testGroup "Dhall round-trip"
   , testCase "Node -> Text via Dhall.function (hostname projection)" $ do
       f <- Dhall.input
         (Dhall.function nodeEncoder Dhall.strictText)
-        "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text }) -> n.hostname"
+        "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text, customAttributes : List { name : Text, command : Text } }) -> n.hostname"
       assertEqual "hostname projection"
         "web01"
-        (f (Node "web01" Nothing (Role "Web") []))
+        (f (Node "web01" Nothing (Role "Web") [] []))
   , testCase "Node -> Text via Dhall.function (role/hostname interpolation)" $ do
       f <- Dhall.input
         (Dhall.function nodeEncoder Dhall.strictText)
-        "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text }) -> \"${n.role}/${n.hostname}_spec.rb\""
+        "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text, customAttributes : List { name : Text, command : Text } }) -> \"${n.role}/${n.hostname}_spec.rb\""
       assertEqual "by-role layout"
         "Web/web01_spec.rb"
-        (f (Node "web01" (Just "10.0.1.10") (Role "Web") ["frontend"]))
+        (f (Node "web01" (Just "10.0.1.10") (Role "Web") ["frontend"] []))
   ]
 
 decodes :: (Eq a, Show a, Dhall.FromDhall a) => Text -> a -> IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -16,6 +16,7 @@ import qualified Property.EmitTest
 import qualified Roundtrip.DhallEncodingTest
 import qualified SoT.TerraformTest
 import qualified Synth.HundredHostsTest
+import qualified Unit.EmitCustomAttributesTest
 import qualified Unit.LayoutTest
 import qualified Unit.ValidateTest
 
@@ -23,6 +24,7 @@ main :: IO ()
 main = defaultMain $ testGroup "paninfraspec"
   [ Unit.ValidateTest.tests
   , Unit.LayoutTest.tests
+  , Unit.EmitCustomAttributesTest.tests
   , Roundtrip.DhallEncodingTest.tests
   , Property.EmitTest.tests
   , Synth.HundredHostsTest.tests

--- a/test/Synth/HundredHostsTest.hs
+++ b/test/Synth/HundredHostsTest.hs
@@ -22,10 +22,11 @@ tests = testGroup "synthetic"
 synthInventory :: [Node]
 synthInventory =
   [ Node
-      { hostname = "h" <> T.pack (show i)
-      , ip       = Just ("10.0." <> T.pack (show (i `div` 50)) <> "." <> T.pack (show (i `mod` 50)))
-      , role     = roleFor i
-      , tags     = if even i then ["metrics"] else []
+      { hostname         = "h" <> T.pack (show i)
+      , ip               = Just ("10.0." <> T.pack (show (i `div` 50)) <> "." <> T.pack (show (i `mod` 50)))
+      , role             = roleFor i
+      , tags             = if even i then ["metrics"] else []
+      , customAttributes = []
       }
   | i <- [1 .. 100 :: Int]
   ]

--- a/test/Unit/EmitCustomAttributesTest.hs
+++ b/test/Unit/EmitCustomAttributesTest.hs
@@ -1,0 +1,200 @@
+module Unit.EmitCustomAttributesTest (tests) where
+
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.IR hiding (Assertion)
+import qualified PanInfraSpec.IR as IR
+import PanInfraSpec.Layout (defaultLayout)
+
+tests :: TestTree
+tests = testGroup "customAttributes & ALRubyExpr"
+  [ testCase "mysql_config CompareExpr renders bare Ruby expression"  mysqlCompareExpr
+  , testCase "php_config CompareExpr renders bare Ruby expression"    phpCompareExpr
+  , testCase "x509_certificate CompareExpr renders bare Ruby expression" x509CompareExpr
+  -- preamble generation
+  , testCase "preamble bound after spec_helper require"    preambleBoundAfterRequire
+  , testCase "preamble emits one line per customAttribute" preambleMultiAttr
+  , testCase "preamble omitted for empty customAttributes" preambleOmittedForEmpty
+  , testCase "preamble: command is shell-quoted via rubyString" preambleEscapesQuotes
+  -- validation
+  , testCase "rejects empty customAttribute name"          rejectsEmptyName
+  , testCase "rejects empty customAttribute command"       rejectsEmptyCommand
+  , testCase "rejects duplicate customAttribute name"      rejectsDuplicateName
+  , testCase "rejects invalid Ruby identifier name"        rejectsInvalidIdentifier
+  ]
+
+-- | Build a single-host single-assertion plan, run the emitter, and return the
+-- generated host spec body as Text.
+emitOne :: Node -> IR.Assertion -> Either Text Text
+emitOne node assertion =
+  let ep = ExecutionPlan "serverspec" [Job node [assertion]]
+  in case emitFor defaultLayout ep of
+       Left e     -> Left e
+       Right outs -> case Map.lookup (T.unpack (hostname node) <> "_spec.rb") outs of
+         Just t  -> Right t
+         Nothing -> Left ("missing spec for " <> hostname node)
+
+emptyNode :: Text -> Node
+emptyNode h = Node
+  { hostname         = h
+  , ip               = Nothing
+  , role             = Role "Web"
+  , tags             = []
+  , customAttributes = []
+  }
+
+assertContains :: Text -> Either Text Text -> IO ()
+assertContains needle = \case
+  Left  e -> assertFailure ("expected Right with " <> show needle <> ", got Left " <> show e)
+  Right t
+    | needle `T.isInfixOf` t -> pure ()
+    | otherwise -> assertFailure
+        ("expected output to contain " <> show needle <> "; got:\n" <> T.unpack t)
+
+-- | mysql_config + AVCompare OpGt (ALRubyExpr ...)  →
+--   its(:value) { should be > <expr> }
+mysqlCompareExpr :: IO ()
+mysqlCompareExpr =
+  let assertion = IR.Assertion "mysql_config" "innodb_buffer_pool_size"
+        (Map.singleton "value"
+           (AVCompare OpGt (ALRubyExpr "paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100")))
+   in assertContains
+        "its(:value) { should be > paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100 }"
+        (emitOne (emptyNode "web01") assertion)
+
+-- | php_config + AVCompare OpLe (ALRubyExpr ...)
+phpCompareExpr :: IO ()
+phpCompareExpr =
+  let assertion = IR.Assertion "php_config" "memory_limit"
+        (Map.singleton "value"
+           (AVCompare OpLe (ALRubyExpr "paninfraspec_php_max_mb.to_i")))
+   in assertContains
+        "its(:value) { should be <= paninfraspec_php_max_mb.to_i }"
+        (emitOne (emptyNode "web01") assertion)
+
+-- | x509_certificate + AVCompare OpGe (ALRubyExpr ...)
+x509CompareExpr :: IO ()
+x509CompareExpr =
+  let assertion = IR.Assertion "x509_certificate" "/etc/ssl/cert.pem"
+        (Map.singleton "validity_in_days"
+           (AVCompare OpGe (ALRubyExpr "paninfraspec_min_cert_days.to_i")))
+   in assertContains
+        "its(:validity_in_days) { should be >= paninfraspec_min_cert_days.to_i }"
+        (emitOne (emptyNode "web01") assertion)
+
+-- | Trivial command assertion used as a stable describe block while we focus
+-- on preamble behaviour.
+unameAssertion :: IR.Assertion
+unameAssertion = IR.Assertion "command" "uname -a"
+  (Map.singleton "exit-status" (AVNat 0))
+
+withCustom :: [CustomAttribute] -> Node -> Node
+withCustom cas n = n { customAttributes = cas }
+
+-- | preamble line lands between `require 'spec_helper'` and the first describe.
+preambleBoundAfterRequire :: IO ()
+preambleBoundAfterRequire =
+  let node = withCustom
+        [CustomAttribute "total_ram_kb" "awk '/MemTotal/ {print $2}' /proc/meminfo"]
+        (emptyNode "web01")
+   in case emitOne node unameAssertion of
+        Left e -> assertFailure ("emit failed: " <> show e)
+        Right t ->
+          let ls = T.lines t
+              -- find the first describe block start
+              hasDescribe = any (\l -> "describe " `T.isPrefixOf` l) ls
+              hasRequire  = any (\l -> "require 'spec_helper'" `T.isPrefixOf` l) ls
+              hasPreamble = any (\l -> "paninfraspec_total_ram_kb" `T.isInfixOf` l) ls
+              orderOk =
+                let ix p = length (takeWhile (not . p) ls)
+                    irq  = ix (\l -> "require 'spec_helper'" `T.isPrefixOf` l)
+                    ipre = ix (\l -> "paninfraspec_total_ram_kb" `T.isInfixOf` l)
+                    idsc = ix (\l -> "describe " `T.isPrefixOf` l)
+                in irq < ipre && ipre < idsc
+          in assertBool
+               ("require/preamble/describe order broken in:\n" <> T.unpack t)
+               (hasRequire && hasPreamble && hasDescribe && orderOk)
+
+-- | Two customAttributes produce two preamble lines, in declaration order.
+preambleMultiAttr :: IO ()
+preambleMultiAttr =
+  let node = withCustom
+        [ CustomAttribute "total_ram_kb" "awk '/MemTotal/ {print $2}' /proc/meminfo"
+        , CustomAttribute "cpu_count"    "nproc"
+        ]
+        (emptyNode "web01")
+   in case emitOne node unameAssertion of
+        Left e  -> assertFailure ("emit failed: " <> show e)
+        Right t -> do
+          assertBool "first preamble missing" $
+            "paninfraspec_total_ram_kb = " `T.isInfixOf` t
+          assertBool "second preamble missing" $
+            "paninfraspec_cpu_count = " `T.isInfixOf` t
+          let firstIdx  = T.length (fst (T.breakOn "paninfraspec_total_ram_kb" t))
+              secondIdx = T.length (fst (T.breakOn "paninfraspec_cpu_count" t))
+          assertBool "preamble order should follow declaration"
+                    (firstIdx < secondIdx)
+
+-- | Empty customAttributes: no preamble line emitted.
+preambleOmittedForEmpty :: IO ()
+preambleOmittedForEmpty =
+  case emitOne (emptyNode "web01") unameAssertion of
+    Left e  -> assertFailure ("emit failed: " <> show e)
+    Right t -> assertBool
+      ("preamble unexpectedly emitted in:\n" <> T.unpack t)
+      (not ("paninfraspec_" `T.isInfixOf` t))
+
+-- | Single-quotes inside the command string are escaped via rubyString.
+preambleEscapesQuotes :: IO ()
+preambleEscapesQuotes =
+  let node = withCustom
+        [CustomAttribute "msg" "echo 'hi'"]
+        (emptyNode "web01")
+   in case emitOne node unameAssertion of
+        Left e  -> assertFailure ("emit failed: " <> show e)
+        Right t -> assertBool
+          ("expected escaped single-quote in:\n" <> T.unpack t)
+          ("'echo \\'hi\\''" `T.isInfixOf` t)
+
+assertEmitLeftContains :: Text -> Node -> IO ()
+assertEmitLeftContains needle node =
+  case emitOne node unameAssertion of
+    Right t -> assertFailure
+      ("expected Left containing " <> show needle <> ", got Right:\n" <> T.unpack t)
+    Left e
+      | needle `T.isInfixOf` e -> pure ()
+      | otherwise -> assertFailure
+          ("expected error containing " <> show needle <> ", got: " <> show e)
+
+rejectsEmptyName :: IO ()
+rejectsEmptyName =
+  assertEmitLeftContains "non-empty" $
+    withCustom [CustomAttribute "" "echo hi"] (emptyNode "web01")
+
+rejectsEmptyCommand :: IO ()
+rejectsEmptyCommand =
+  assertEmitLeftContains "non-empty" $
+    withCustom [CustomAttribute "x" ""] (emptyNode "web01")
+
+rejectsDuplicateName :: IO ()
+rejectsDuplicateName =
+  assertEmitLeftContains "duplicate" $
+    withCustom
+      [ CustomAttribute "x" "echo a"
+      , CustomAttribute "x" "echo b"
+      ]
+      (emptyNode "web01")
+
+rejectsInvalidIdentifier :: IO ()
+rejectsInvalidIdentifier = do
+  assertEmitLeftContains "valid" $
+    withCustom [CustomAttribute "9foo" "echo a"] (emptyNode "web01")
+  assertEmitLeftContains "valid" $
+    withCustom [CustomAttribute "with space" "echo a"] (emptyNode "web01")
+  assertEmitLeftContains "valid" $
+    withCustom [CustomAttribute "Foo" "echo a"] (emptyNode "web01")

--- a/test/Unit/LayoutTest.hs
+++ b/test/Unit/LayoutTest.hs
@@ -55,7 +55,7 @@ tests = testGroup "Layout"
   ]
 
 mkNode :: Text -> Text -> Node
-mkNode h r = Node h Nothing (Role r) []
+mkNode h r = Node h Nothing (Role r) [] []
 
 -- | Smallest assertion that survives layer-3 validation: a uname command
 -- check. Used so the focus stays on the layout / collision behaviour rather
@@ -66,7 +66,7 @@ pingAssertion = Assertion "command" "uname -a"
 
 nodeFnDhall :: Text
 nodeFnDhall =
-  "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text }) \
+  "\\(n : { hostname : Text, ip : Optional Text, role : Text, tags : List Text, customAttributes : List { name : Text, command : Text } }) \
   \-> \"${n.role}/${n.hostname}_spec.rb\""
 
 assertLeftContains :: Show a => Text -> Either Text a -> IO ()

--- a/test/Unit/ValidateTest.hs
+++ b/test/Unit/ValidateTest.hs
@@ -36,7 +36,13 @@ assertLeftContains needle = \case
   Right _ -> assertFailure ("expected Left containing " <> show needle <> ", got Right")
 
 mkNode :: Text -> Node
-mkNode h = Node { hostname = h, ip = Nothing, role = Role "Web", tags = [] }
+mkNode h = Node
+  { hostname         = h
+  , ip               = Nothing
+  , role             = Role "Web"
+  , tags             = []
+  , customAttributes = []
+  }
 
 layer1TargetMismatch :: IO ()
 layer1TargetMismatch =


### PR DESCRIPTION
## Summary
- Add `Inventory.customAttributes` (`List { name, command }`) so each host can declare shell commands whose stdout is bound to a Ruby variable (`paninfraspec_<name>`) at the top of the generated spec.
- Add `AttrLeaf.ALRubyExpr` so plans can flow bare Ruby expressions through `AVCompare`-shaped matchers (rendered without `rubyString` quoting).
- Add `expand_attr : Text -> Text` to the Dhall prelude — the only place the `paninfraspec_` prefix appears, so plans never hard-code the naming convention.
- Add `CompareExpr` to `MysqlConfigState` and `PhpConfigState`, and `ValidityInDaysCompareExpr` to `X509CertificateState`.
- Validate `customAttribute` names as Ruby local identifiers (`^[a-z_][a-zA-Z0-9_]*$`) and reject empty names, empty commands, and duplicates fail-fast in `formatJob` before any output is written.
- Update the flat Golden (`web01`) to demonstrate `customAttributes` + `CompareExpr` end to end; the `by_role` Golden stays unchanged since its hosts declare `customAttributes = []`.
- Update `examples/inventory.dhall` (db01 grows a `total_ram_kb` attribute) and `examples/plan.dhall` (`Plan.forRole "DBPrimary"` asserts `innodb_buffer_pool_size` is at least 70% of total RAM via `expand_attr`).
- Document the feature in `README.md` (new "Per-host dynamic expected values" section).

Closes #15.

## Test plan
- [x] `cabal build all`
- [x] `cabal test all` — 68 tests pass (Unit / Property / Roundtrip / Synth / SoT / Golden)
- [x] New unit suite `Unit.EmitCustomAttributesTest` covers preamble placement, multi-attribute ordering, omission for empty `customAttributes`, single-quote escaping in commands, the three `CompareExpr` Ruby outputs, and validation errors (empty name, empty command, duplicate name, invalid identifier).
- [x] New Roundtrip cases for `AttrLeaf.ALRubyExpr`, `AVCompare` carrying `ALRubyExpr`, and `CustomAttribute`.
- [x] Manual E2E: `cabal run paninfraspec-gen -- --inventory examples/inventory.dhall --plan examples/plan.dhall --target serverspec --out /tmp/out` — `web01_spec.rb` has no preamble, `db01_spec.rb` binds `paninfraspec_total_ram_kb` and emits `mysql_config('innodb_buffer_pool_size')` with `should be >= paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)