### PR TITLE
Make examples self-contained via GitHub URL imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,18 @@ on:
 permissions:
   contents: read
 
+# Cancel duplicate runs from push + pull_request triggers on the same ref,
+# and supersede in-flight runs when a newer commit lands.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test (${{ matrix.os }})
+    # Default job timeout is 360 minutes; cap at 20 so a stuck cabal-test step
+    # surfaces as a quick failure instead of sitting for hours.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -51,4 +60,7 @@ jobs:
 
       - run: cabal update
       - run: cabal build all --enable-tests
-      - run: cabal test all --test-show-details=streaming
+      # `direct` connects the test executable's stdout/stderr straight to the
+      # job log instead of going through cabal's streaming pipe, which has been
+      # observed to deadlock at EOF on all three OSes.
+      - run: cabal test all --test-show-details=direct

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
 permissions:
   contents: read
 
-# Cancel duplicate runs from push + pull_request triggers on the same ref,
-# and supersede in-flight runs when a newer commit lands.
+# Cancel duplicate runs from push + pull_request triggers on the same branch,
+# and supersede in-flight runs when a newer commit lands. `github.head_ref` is
+# set on pull_request events to the source branch and empty otherwise; falling
+# back to `github.ref_name` gives the same key for both event types.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   test:
     name: test (${{ matrix.os }})
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +51,7 @@ jobs:
 
       - run: cabal update
       - run: cabal build all --enable-tests
-      - run: cabal test all --test-show-details=streaming
+      - run: cabal test all --test-show-details=direct
 
   build-linux:
     name: build linux ${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ An inventory is a Dhall file that returns a list of nodes. See
 [`examples/inventory.dhall`](./examples/inventory.dhall):
 
 ```dhall
-let I = ../dhall/Inventory.dhall
+-- Pin to a tag and `dhall freeze` for production use.
+let I = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Inventory.dhall
 
 in  [ { hostname = "web01", ip = Some "10.0.1.10", role = "Web",       tags = [ "frontend", "metrics" ] }
     , { hostname = "web02", ip = Some "10.0.1.11", role = "Web",       tags = [ "frontend" ] }
@@ -76,8 +77,9 @@ list of *assertions*, and a node receives every assertion from every mapping
 whose selector matches it. See [`examples/plan.dhall`](./examples/plan.dhall):
 
 ```dhall
-let Spec = ../dhall/Serverspec.dhall
-let Plan = ../dhall/Plan.dhall
+-- Pin to a tag and `dhall freeze` for production use.
+let Spec = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Serverspec.dhall
+let Plan = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Plan.dhall
 
 let baseSpec  = [ Spec.command "uname -a" (Spec.CommandState.ExitCode 0) ]
 let nginxSpec =
@@ -120,15 +122,17 @@ layout file and pass it with `--layout`:
 
 ```dhall
 -- examples/layout-by-role.dhall
-let L = ../dhall/Layout.dhall
+-- Pin to a tag and `dhall freeze` for production use.
+let L = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Layout.dhall
 in  L.byRole   -- spec files under <role>/<hostname>_spec.rb
 ```
 
 Or roll your own with the full Dhall expression power:
 
 ```dhall
-let I = ../dhall/Inventory.dhall
-let L = ../dhall/Layout.dhall
+-- Pin to a tag and `dhall freeze` for production use.
+let I = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Inventory.dhall
+let L = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Layout.dhall
 
 in  L.make
       { specPath = \(n : I.Node) ->
@@ -224,7 +228,8 @@ names/commands are rejected at generate time.
 **Step 2: reference it from the plan with `expand_attr`.**
 
 ```dhall
-let Spec = ../dhall/Serverspec.dhall
+-- Pin to a tag and `dhall freeze` for production use.
+let Spec = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Serverspec.dhall
 
 in  Spec.mysqlConfig "innodb_buffer_pool_size"
       ( Spec.MysqlConfigState.CompareExpr

--- a/examples/inventory.dhall
+++ b/examples/inventory.dhall
@@ -1,7 +1,10 @@
 -- examples/inventory.dhall
 -- Sample inventory: 3 nodes. db01 has no IP to exercise Optional Text round-trip.
 
-let I = ../dhall/Inventory.dhall
+-- Resolves to the latest `main` of this repository.
+-- For production use, pin to a release tag (e.g. v0.2.0.0) and run
+-- `dhall freeze` to attach an integrity SHA-256 hash to this import.
+let I = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Inventory.dhall
 
 in  [ { hostname         = "web01"
       , ip               = Some "10.0.1.10"

--- a/examples/layout-by-role.dhall
+++ b/examples/layout-by-role.dhall
@@ -3,6 +3,9 @@
 -- node's spec at @<role>/<hostname>_spec.rb@ rather than at the top of the
 -- output directory.
 
-let L = ../dhall/Layout.dhall
+-- Resolves to the latest `main` of this repository.
+-- For production use, pin to a release tag (e.g. v0.2.0.0) and run
+-- `dhall freeze` to attach an integrity SHA-256 hash to this import.
+let L = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Layout.dhall
 
 in  L.byRole

--- a/examples/plan.dhall
+++ b/examples/plan.dhall
@@ -2,9 +2,12 @@
 -- Mapping rules: every node gets a baseline check; Web nodes get an nginx stack;
 -- anything tagged "metrics" gets a Prometheus port check.
 
-let Spec = ../dhall/Serverspec.dhall
+-- The two imports below resolve to the latest `main` of this repository.
+-- For production use, pin to a release tag (e.g. v0.2.0.0) and run
+-- `dhall freeze` to attach an integrity SHA-256 hash to each import.
+let Spec = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Serverspec.dhall
 
-let Plan = ../dhall/Plan.dhall
+let Plan = https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/Plan.dhall
 
 let baseSpec
     : List Spec.Assertion


### PR DESCRIPTION
## Summary
- Switch `examples/{plan,layout-by-role,inventory}.dhall` imports from `../dhall/...` relative paths to `https://raw.githubusercontent.com/ikaro1192/PanInfraSpec/main/dhall/...` URLs so users can copy an example file anywhere and run it without cloning the repo.
- Add a short comment above each URL recommending pinning to a release tag (e.g. `v0.2.0.0`) and running `dhall freeze` for production use.
- Update the matching code snippets in `README.md` to keep the docs in sync with the actual files.
- `dhall/` preludes themselves keep their relative imports (`./Serverspec.dhall` etc.) — Dhall resolves these relative to the parent URL when fetched remotely, so the URL-based user flow still works while local development and `test/Golden/*` remain network-free.

## Test plan
- [x] `cabal test` — all 68 tests still pass (Golden tests use local relative imports, unaffected).
- [x] `cabal run paninfraspec-gen -- --inventory examples/inventory.dhall --plan examples/plan.dhall --layout examples/layout-by-role.dhall --target serverspec --out /tmp/out` — fetches the preludes from GitHub `main` and produces `Web/web0{1,2}_spec.rb`, `DBPrimary/db01_spec.rb`, `spec_helper.rb`, `Rakefile` with `paninfraspec_total_ram_kb` correctly expanded.
- [ ] Manual: `dhall freeze --inplace examples/plan.dhall` produces an inline `sha256:...` hash on each URL (revert after checking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)