### PR TITLE
Ship Linux tarball release assets (closes #23)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,18 @@ jobs:
           done
           ls -la out/
 
+      - name: Package tarball
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          NAME="paninfraspec-${VERSION}-linux-${{ matrix.arch }}"
+          mkdir -p "$NAME/bin"
+          cp staging/usr/local/bin/paninfraspec-gen "$NAME/bin/paninfraspec-gen"
+          cp LICENSE README.md "$NAME"/
+          mkdir -p out
+          tar -czf "out/$NAME.tar.gz" "$NAME"
+          ls -la out/
+
       - uses: actions/upload-artifact@v4
         with:
           name: linux-${{ matrix.arch }}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,39 @@ files DRY, type-checked, and easy to regenerate when your inventory changes.
 
 ## Install
 
+### From a release asset
+
+Pre-built `paninfraspec-gen` binaries are published on every tag at
+[GitHub Releases](https://github.com/ikaro1192/PanInfraSpec/releases/latest).
+
+| Platform | Asset |
+|---|---|
+| Linux x86_64 | `paninfraspec-<version>-linux-x86_64.tar.gz` (also `.deb` / `.rpm`) |
+| Linux aarch64 | `paninfraspec-<version>-linux-aarch64.tar.gz` (also `.deb` / `.rpm`) |
+| macOS arm64 | `paninfraspec-<version>-darwin-arm64.tar.gz` |
+| Windows x86_64 | `paninfraspec-<version>-windows-x86_64.zip` |
+
+Tarball install (Linux / macOS):
+
+```sh
+VERSION=0.4.0          # pick the tag you want
+ARCH=linux-x86_64      # or linux-aarch64, darwin-arm64
+curl -L "https://github.com/ikaro1192/PanInfraSpec/releases/download/v${VERSION}/paninfraspec-${VERSION}-${ARCH}.tar.gz" \
+  | tar -xz
+sudo mv "paninfraspec-${VERSION}-${ARCH}/bin/paninfraspec-gen" /usr/local/bin/
+```
+
+The Linux tarballs are dynamically linked against glibc, so they work on
+Ubuntu / Debian / RHEL / Fedora and most other glibc-based distros. Alpine
+and other musl-based distros are not yet covered by the prebuilt assets;
+build from source there until a musl-static asset is added.
+
+On Debian/Ubuntu and RHEL/Fedora the `.deb` / `.rpm` from the same release
+are an alternative if you want package-manager integration (uninstall,
+upgrade tracking).
+
+### From source
+
 ```sh
 cabal build
 ```


### PR DESCRIPTION
## Summary
- Add a `Package tarball` step to the `build-linux` job in `.github/workflows/release.yml` so each tag publishes `paninfraspec-<version>-linux-x86_64.tar.gz` and `paninfraspec-<version>-linux-aarch64.tar.gz` alongside the existing `.deb` / `.rpm` assets.
- Reuse the already-stripped binary staged for `.deb` / `.rpm` to avoid stripping twice; the new artifact is dropped in `out/` so the existing `upload-artifact` and final `dist/*.tar.gz` glob in the `release` job pick it up unchanged.
- Restructure README `## Install` into "From a release asset" and "From source" subsections, document the tarball curl one-liner for Linux and macOS, and note that Alpine / musl distros are not yet covered (musl-static is a follow-up).

## Test plan
- [ ] CI on this PR remains green (release workflow does not run on PR events; this is structural only).
- [ ] After merge, cut a prerelease tag (e.g. `v0.4.1-dryrun`) and confirm the release run produces both `paninfraspec-<ver>-linux-x86_64.tar.gz` and `paninfraspec-<ver>-linux-aarch64.tar.gz` in the GitHub Release.
- [ ] Download the x86_64 tarball on Ubuntu LTS and Debian stable, extract, and confirm `paninfraspec-gen --help` works.
- [ ] (Expected to fail until musl-static follow-up) Same check on Alpine; documented as not yet supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)