### PR TITLE
Install pkg-config and zlib1g-dev in Docker builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,13 @@ FROM haskell:9.6.7 AS builder
 
 WORKDIR /src
 
+# `cabal.project.freeze` pins `zlib -bundled-c-zlib +pkg-config`, so the
+# Haskell zlib bindings need a system zlib + pkg-config at build time. The
+# official haskell:9.6.7 image (Debian Bookworm) ships neither.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends pkg-config zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY cabal.project cabal.project.freeze paninfraspec.cabal ./
 
 RUN cabal update \


### PR DESCRIPTION
## Summary
- Apt-install `pkg-config` and `zlib1g-dev` in the `haskell:9.6.7` builder stage so the Haskell `zlib` bindings find a system zlib via pkg-config and `cabal build --only-dependencies` can solve.
- The runtime stage (`gcr.io/distroless/cc-debian12`) is unchanged.

## Why
`cabal.project.freeze` pins `zlib -bundled-c-zlib +pkg-config`. The official `haskell:9.6.7` image (Debian Bookworm) ships neither pkg-config nor zlib1g-dev, so on the v0.4.0.1 release run both `docker-amd64` and `docker-arm64` failed during dependency solving:

\`\`\`
[__8] rejecting: zlib:+pkg-config (pkg-config package zlib-any is needed but no pkg-config executable was found or querying it failed)
[__8] rejecting: zlib:-pkg-config (constraint from project config cabal.project.freeze requires opposite flag selection)
\`\`\`

The existing host-Linux release jobs (`build-linux`) didn't see this because the GitHub Actions Ubuntu runner image already has both installed.

## Test plan
- [ ] PR CI (`test` matrix on Ubuntu / macOS / Windows) stays green — no Haskell code changes.
- [ ] After merge, push tag `v0.4.0.2`. Verify both `docker-amd64` and `docker-arm64` jobs reach the `Smoke-test --help` step and pass; `docker-manifest` publishes the multi-arch tag set to `ghcr.io/ikaro1192/paninfraspec-gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)