### PR TITLE
Collapse Dockerfile builder into a single COPY+install step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends pkg-config zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-COPY cabal.project cabal.project.freeze paninfraspec.cabal ./
-
-RUN cabal update \
- && cabal build --only-dependencies exe:paninfraspec-gen
-
 COPY . .
 
-RUN cabal install exe:paninfraspec-gen \
+# A two-step "manifests first, sources later" layer split is tempting for
+# caching, but Cabal 3.10's `--only-dependencies` still preprocesses the
+# in-package library (executable depends on it), which fails before the
+# source tree is COPY'd. Just build everything in one RUN.
+RUN cabal update \
+ && cabal install exe:paninfraspec-gen \
       --installdir=/out \
       --install-method=copy \
       --overwrite-policy=always \


### PR DESCRIPTION
## Summary
- Drop the "manifests first, sources later" layer split in `Dockerfile`. Now the builder stage does one `COPY . .` followed by one `cabal update && cabal install exe:paninfraspec-gen ...`.

## Why
The previous structure relied on `cabal build --only-dependencies exe:paninfraspec-gen` to skip building the in-package library. In practice Cabal 3.10 still preprocesses the executable's dependency on the local `paninfraspec` library; with only the cabal manifests COPY'd in, preprocess can't find `src/PanInfraSpec/IR.hs`. This caused the v0.4.0.2 release run's `docker (arm64)` job to fail (`Error: [Cabal-7554] can't find source for PanInfraSpec/IR in src, ...`); `docker (amd64)` was on the same path.

CI rebuilds from scratch on every tag, so the lost layer-cache reuse doesn't change real-world build time. Local `docker build` still benefits from BuildKit step caching at the RUN boundary.

## Test plan
- [ ] PR CI (`test` matrix) stays green — no Haskell code changes.
- [ ] After merge, push tag `v0.4.0.3`. Verify both `docker (amd64)` and `docker (arm64)` jobs reach the `Smoke-test --help` step and pass; `docker-manifest` publishes `0.4.0.3` / `0.4.0` / `0.4` / `latest` to ghcr.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)