### PR TITLE
Use bundled-c-zlib in Docker builder so the binary needs no system libz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,15 @@ FROM haskell:9.6.7 AS builder
 
 WORKDIR /src
 
-# `cabal.project.freeze` pins `zlib -bundled-c-zlib +pkg-config`, so the
-# Haskell zlib bindings need a system zlib + pkg-config at build time. The
-# official haskell:9.6.7 image (Debian Bookworm) ships neither.
-RUN apt-get update \
- && apt-get install -y --no-install-recommends pkg-config zlib1g-dev \
- && rm -rf /var/lib/apt/lists/*
-
 COPY . .
+
+# Switch the Haskell `zlib` binding to its bundled C source so the resulting
+# executable has no runtime dependency on libz.so.1 — that library is absent
+# from gcr.io/distroless/cc-debian12 where the binary is shipped, and was
+# causing `paninfraspec-gen --help` to fail with "cannot open shared object
+# file: libz.so.1". This mirrors the Windows release job's freeze patch.
+RUN sed -i 's/zlib -bundled-c-zlib +non-blocking-ffi +pkg-config/zlib +bundled-c-zlib +non-blocking-ffi -pkg-config/' cabal.project.freeze \
+ && grep '^             zlib ' cabal.project.freeze
 
 # A two-step "manifests first, sources later" layer split is tempting for
 # caching, but Cabal 3.10's `--only-dependencies` still preprocesses the


### PR DESCRIPTION
## Summary
- Patch \`cabal.project.freeze\` inside the Docker builder stage to flip \`zlib -bundled-c-zlib +pkg-config\` → \`zlib +bundled-c-zlib -pkg-config\` before \`cabal install\`. The Haskell \`zlib\` package then compiles its bundled C zlib in, and the resulting executable has no runtime libz dependency.
- Drop the previously-added \`pkg-config\` / \`zlib1g-dev\` apt install in the builder stage — only needed when linking against the system zlib.

## Why
\`cabal.project.freeze\` keeps \`zlib -bundled-c-zlib +pkg-config\` for native release builds, where Linux/macOS runners do have a system zlib. Inside the Docker image we ship the binary on \`gcr.io/distroless/cc-debian12\`, which provides libc / libgcc / libstdc++ / libgmp but **not** \`libz.so.1\`. v0.4.0.3 built and pushed cleanly, then the per-arch \`Smoke-test --help\` step failed:

\`\`\`
/usr/local/bin/paninfraspec-gen: error while loading shared libraries:
libz.so.1: cannot open shared object file: No such file or directory
\`\`\`

The Windows release job already applies this exact freeze patch for the same reason (no system zlib on the runner). Reusing the trick keeps the canonical freeze unchanged for native release artifacts while making the Docker binary self-contained.

## Test plan
- [ ] PR CI (test matrix on Ubuntu / macOS / Windows) stays green — no Haskell code changes.
- [ ] After merge, push tag \`v0.4.0.4\`. Verify both \`docker (amd64)\` and \`docker (arm64)\` jobs reach and pass the \`Smoke-test --help\` step, then \`docker-manifest\` publishes \`0.4.0.4\` / \`0.4.0\` / \`0.4\` / \`latest\` to \`ghcr.io/ikaro1192/paninfraspec-gen\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)