### PR TITLE
Switch Docker runtime base from distroless/cc to debian:bookworm-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,10 @@ WORKDIR /src
 
 COPY . .
 
-# Switch the Haskell `zlib` binding to its bundled C source so the resulting
-# executable has no runtime dependency on libz.so.1 — that library is absent
-# from gcr.io/distroless/cc-debian12 where the binary is shipped, and was
-# causing `paninfraspec-gen --help` to fail with "cannot open shared object
-# file: libz.so.1". This mirrors the Windows release job's freeze patch.
+# Statically link zlib via the bundled C source so the runtime image
+# doesn't need libz.so.1. This mirrors the Windows release job's freeze
+# patch — the canonical freeze keeps `+pkg-config -bundled-c-zlib` for
+# native release builds where the runner has a system zlib.
 RUN sed -i 's/zlib -bundled-c-zlib +non-blocking-ffi +pkg-config/zlib +bundled-c-zlib +non-blocking-ffi -pkg-config/' cabal.project.freeze \
  && grep '^             zlib ' cabal.project.freeze
 
@@ -25,7 +24,17 @@ RUN cabal update \
       --overwrite-policy=always \
       --enable-executable-stripping
 
-FROM gcr.io/distroless/cc-debian12
+# Use Debian slim (not distroless) for the runtime: the GHC-produced binary
+# pulls in libgmp / libffi / libtinfo / libstdc++ via terminfo and base
+# runtime, and chasing each missing .so on distroless/cc one tag at a time
+# (libz.so.1 → libtinfo.so.6 → ...) was an endless game. apt resolves the
+# full closure in one shot.
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libgmp10 libffi8 libtinfo6 libstdc++6 \
+ && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /out/paninfraspec-gen /usr/local/bin/paninfraspec-gen
 


### PR DESCRIPTION
## Summary
- Replace the runtime stage base in \`Dockerfile\`: \`gcr.io/distroless/cc-debian12\` → \`debian:bookworm-slim\`.
- Apt-install the GHC binary's full runtime closure (\`libgmp10\`, \`libffi8\`, \`libtinfo6\`, \`libstdc++6\`).
- Keep the \`+bundled-c-zlib\` freeze patch in the builder stage so zlib stays statically linked and \`libz1\` is intentionally absent from the apt list.

## Why
The GHC-produced executable dynamically links against libgmp, libffi, libtinfo, and libstdc++ on top of glibc. distroless/cc-debian12 ships glibc + libstdc++ + libgmp but **not libtinfo** (and not zlib).

Chasing each missing \`.so\` one tag at a time was unbounded:
- v0.4.0.3 → \`libz.so.1: cannot open shared object file\`
- v0.4.0.4 → \`libtinfo.so.6: cannot open shared object file\`
- next would likely be \`libffi.so.8\` or another transitive dep

Using debian:bookworm-slim with an explicit apt list resolves the full closure in one shot. The image grows from ~25MB (distroless/cc) to ~35MB, well within Issue #22's "small image" intent.

## Test plan
- [ ] PR CI (test matrix on Ubuntu / macOS / Windows) stays green — no Haskell code changes.
- [ ] After merge, push tag \`v0.4.0.5\`. Verify both \`docker (amd64)\` and \`docker (arm64)\` jobs reach and pass the \`Smoke-test --help\` step. Verify \`docker-manifest\` publishes \`0.4.0.5\` / \`0.4.0\` / \`0.4\` / \`latest\` to ghcr.io.
- [ ] Verify \`create github release\` succeeds (the v0.4.0.4 failure was a transient \`download-artifact\` retry exhaustion; it should self-resolve on the next run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)