### PR TITLE
Use type=match patterns for Cabal/PVP 4-component version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,10 +382,13 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.image.outputs.name }}
+          # Cabal/PVP versions are 4-component (e.g. v0.4.0.6) so `type=semver`
+          # silently skips them — semver only accepts MAJOR.MINOR.PATCH.
+          # Match the Cabal shape explicitly with regex captures.
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}.{{patch}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=match,pattern=^v(\d+\.\d+\.\d+\.\d+)$,group=1
+            type=match,pattern=^v(\d+\.\d+\.\d+)\.\d+$,group=1
+            type=match,pattern=^v(\d+\.\d+)\.\d+\.\d+$,group=1
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Create multi-arch manifest and push


### PR DESCRIPTION
## Summary
Switch the docker-manifest job's \`docker/metadata-action\` from \`type=semver\` to explicit \`type=match\` regex patterns that understand 4-component Cabal/PVP version tags.

## Why
\`metadata-action\`'s \`type=semver\` only accepts strict 3-component semver (\`MAJOR.MINOR.PATCH\`). PanInfraSpec uses Cabal/PVP 4-component versions (\`v0.4.0.6\`), which semver silently rejects. As a result the v0.4.0.6 release run published only \`:latest\` to GHCR; \`:0.4.0.6\` / \`:0.4.0\` / \`:0.4\` were never generated. Confirmed via the docker-manifest job log:

\`\`\`
DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/ikaro1192/paninfraspec-gen:latest
\`\`\`

Confirmed via local pull: \`ghcr.io/ikaro1192/paninfraspec-gen:latest\` resolves; \`:0.4.0.6\` does not.

## Patterns

| git tag    | resulting Docker tags                  |
|------------|----------------------------------------|
| v0.4.0.6   | \`0.4.0.6\`, \`0.4.0\`, \`0.4\`, \`latest\` |
| v1.2.3.4   | \`1.2.3.4\`, \`1.2.3\`, \`1.2\`, \`latest\` |
| v1.2.3.4-rc1 | (no match — \`latest\` also gated off) |

## Test plan
- [ ] PR CI (test matrix) green — no Haskell code changes.
- [ ] After merge, push tag \`v0.4.0.7\`. Verify \`docker manifest\` job's \`DOCKER_METADATA_OUTPUT_TAGS\` lists all four tags. Verify \`docker manifest inspect ghcr.io/ikaro1192/paninfraspec-gen:0.4.0.7\` (and \`:0.4.0\`, \`:0.4\`, \`:latest\`) all resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)