### PR TITLE
Disable docker/build-push-action build-summary artifact upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,6 +325,14 @@ jobs:
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
+        # docker/build-push-action@v6 auto-uploads a `*.dockerbuild` build
+        # summary as a workflow artifact. Those files aren't valid zip
+        # archives, and the `release` job's `download-artifact@v4` (which
+        # pulls every artifact in the run) fails with "Artifact download
+        # failed after 5 retries" when it tries to extract them. Suppress
+        # the upload — the build summary is still visible in the run UI.
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: "false"
         with:
           context: .
           platforms: ${{ matrix.platform.name }}


### PR DESCRIPTION
## Summary
Set \`DOCKER_BUILD_RECORD_UPLOAD: "false"\` on the docker matrix's \`docker/build-push-action@v6\` step so it stops auto-uploading a \`<repo>~<run>.dockerbuild\` workflow artifact.

## Why
\`docker/build-push-action@v6\` unconditionally uploads a build-summary file as a workflow artifact (e.g. \`ikaro1192~PanInfraSpec~E984LR.dockerbuild\`). Our \`release\` job's \`actions/download-artifact@v4\` step pulls every artifact in the run with no \`pattern\` filter and tries to unzip each one. The .dockerbuild files aren't valid zip archives, so the step fails deterministically with:

\`\`\`
Unable to download and extract artifact: Artifact download failed after 5 retries.
\`\`\`

The v0.4.0.4, v0.4.0.6, and v0.4.0.7 release runs all hit this once docker jobs were added in PR #26 — three reruns of the v0.4.0.7 release job all failed the same way.

Suppressing the upload is the cleanest fix; the build summary stays visible in the GitHub Actions run UI (only the artifact upload is disabled), and the release job's existing pattern-less download-artifact + per-OS asset glob keep working unchanged.

Credit to @ikaro1192 for spotting the build-push-action / download-artifact spec collision.

## Test plan
- [ ] PR CI (test matrix) green — no Haskell code changes.
- [ ] After merge, push tag \`v0.4.0.8\`. Verify \`docker (amd64)\`, \`docker (arm64)\`, \`docker manifest\`, **and** \`create github release\` all succeed in one go. Verify \`gh release view v0.4.0.8\` lists .deb / .rpm / .tar.gz / .zip assets, and \`docker pull ghcr.io/ikaro1192/paninfraspec-gen:0.4.0.8\` works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)