### PR TITLE
Document Homebrew install option for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ files DRY, type-checked, and easy to regenerate when your inventory changes.
 
 ## Install
 
+### Homebrew (macOS)
+
+```sh
+brew install ikaro1192/tap/paninfraspec
+```
+
+The formula lives in [ikaro1192/homebrew-tap](https://github.com/ikaro1192/homebrew-tap)
+and builds `paninfraspec-gen` from source via `cabal-install` / `ghc` (pulled in
+as build dependencies). Works on both Apple Silicon and Intel Macs.
+
 ### From a release asset
 
 Pre-built `paninfraspec-gen` binaries are published on every tag at


### PR DESCRIPTION
## Summary
- Add a Homebrew (macOS) subsection at the top of the Install section, pointing to the existing `ikaro1192/homebrew-tap` formula.
- The tap builds `paninfraspec-gen` from source via `cabal-install` / `ghc`, and works on both Apple Silicon and Intel Macs.

## Test plan
- [ ] Render README on GitHub and confirm the new section displays correctly above "From a release asset".
- [ ] Verify the tap link resolves to https://github.com/ikaro1192/homebrew-tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)