### PR TITLE
Use paninfraspec-gen directly in Quickstart examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ running `rake spec` afterwards is still the user's responsibility.
 ## Quickstart
 
 ```sh
-cabal run paninfraspec-gen -- \
+paninfraspec-gen \
   --inventory examples/inventory.dhall \
   --plan      examples/plan.dhall \
   --target    serverspec \
@@ -118,7 +118,7 @@ pass `--scaffold PATH` to load a different one.
 | `dhall/Scaffold/AnsibleSpec.dhall` | `L.ansibleSpec` | `Rakefile`, `spec_helper.rb`, `hosts`, `site.yml` |
 
 ```sh
-cabal run paninfraspec-gen -- \
+paninfraspec-gen \
   --inventory examples/inventory-ansible-spec.dhall \
   --plan      examples/plan-with-modules.dhall \
   --target    serverspec \


### PR DESCRIPTION
## Summary
- Replace `cabal run paninfraspec-gen --` with the bare `paninfraspec-gen` invocation in the Quickstart and Choosing-a-scaffold examples.
- The README now leads with installed-binary install paths (Homebrew / release asset / Docker), so the runnable examples should assume the binary is on `PATH` rather than requiring a source checkout.
- The "From source" section still shows `cabal build` — that one is the appropriate context for source-tree commands.

## Test plan
- [ ] Render README on GitHub and confirm both example blocks now invoke `paninfraspec-gen` directly.
- [ ] Spot-check that no other instructional `cabal run` reference was missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)