### PR TITLE
Drop misleading build-deps note from Homebrew section

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ brew install ikaro1192/tap/paninfraspec
 ```
 
 The formula lives in [ikaro1192/homebrew-tap](https://github.com/ikaro1192/homebrew-tap)
-and builds `paninfraspec-gen` from source via `cabal-install` / `ghc` (pulled in
-as build dependencies). Works on both Apple Silicon and Intel Macs.
+and builds `paninfraspec-gen` from source, so the first install takes a few
+minutes. Works on both Apple Silicon and Intel Macs.
 
 ### From a release asset
 


### PR DESCRIPTION
## Summary
- Replace the "(pulled in as build dependencies)" parenthetical with a more useful subtext.
- The original wording suggested users needed to install `cabal-install` / `ghc` themselves, but Homebrew resolves those automatically — so the note added no value and risked confusing first-time users.
- New wording instead flags the practical implication: the formula compiles from source, so the first install takes a few minutes.

## Test plan
- [ ] Render README on GitHub and confirm the Homebrew section reads cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)