### PR TITLE
Add PerRole sharing mode to Layout for role-shared spec files

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run --rm -v "$PWD":/work \
   --out       /work/out
 ```
 
-Each release publishes `latest`, the full version (`0.4.0.0`), and pin-friendly
+Each release publishes `latest`, the full version (`0.5.0.0`), and pin-friendly
 `major.minor` / `major.minor.patch` tags to
 [ghcr.io/ikaro1192/paninfraspec-gen](https://github.com/ikaro1192/PanInfraSpec/pkgs/container/paninfraspec-gen).
 Built for `linux/amd64` and `linux/arm64`. The image only generates spec files;
@@ -237,10 +237,28 @@ role — write a Dhall layout file and pass it with `--layout`. The shipped
 prelude provides two ready-made layouts:
 
 - `L.byGroupProduct` — `<role>/<module>_spec.rb` when a module label is
-  set, `<role>/<hostname>_spec.rb` otherwise.
+  set, `<role>/<hostname>_spec.rb` otherwise. **PerRole** (see below).
 - `L.ansibleSpec` — `spec/<role>/<module>_spec.rb` / `spec/<role>/<hostname>_spec.rb`,
   matching the [ansible_spec gem's](https://github.com/volanja/ansible_spec)
-  Rakefile expectations.
+  Rakefile expectations. **PerRole** (see below).
+
+### PerHost vs PerRole
+
+A layout declares how multiple hosts in the same role collapse onto
+output files:
+
+- **PerHost** (default; `L.make { specPath = ... }`) — every (node, module)
+  pair must map to a distinct file. The generator fails fast if `specPath`
+  is non-injective. Required when nodes carry `customAttributes`, since
+  those are per-host runtime values rendered into a host-specific preamble.
+- **PerRole** (`L.makePerRole { ... }`, also `L.byGroupProduct`,
+  `L.ansibleSpec`) — a `specPath` that drops the hostname (e.g.
+  `${role}/${module}_spec.rb`) is intended to be a role-shared file.
+  Multiple hosts in the same role merge into a single file when their
+  generated content matches; differing content fails. Per-host execution
+  is expected to come from the runner (the shipped ansible_spec Rakefile
+  iterates the inventory and sets `TARGET_HOST` per host). PerRole layouts
+  reject any node with non-empty `customAttributes`.
 
 Or roll your own:
 

--- a/dhall/Layout.dhall
+++ b/dhall/Layout.dhall
@@ -11,51 +11,89 @@
 --
 -- The auxiliary file paths (Rakefile, spec_helper.rb, ...) are owned by the
 -- scaffold (see dhall/Scaffold.dhall), not by the layout.
+--
+-- Sharing modes
+--   PerHost  Each (node, module) maps to a distinct file. specPath MUST be
+--            injective over the inventory: two hosts in the same role + module
+--            cannot collapse to the same path or emit fails fast.
+--   PerRole  A specPath that hostname-erases (e.g. `${role}/${module}_spec.rb`)
+--            is interpreted as a role-shared spec. Multiple hosts in the same
+--            role are merged into a single output file when their generated
+--            content matches; per-host runs are expected to come from the
+--            scaffold-side runner (e.g. ansible_spec's Rakefile sets
+--            TARGET_HOST per host). `customAttributes` are host-specific and
+--            therefore rejected at emit time in PerRole mode.
 
 let I = ./Inventory.dhall
 
+let Sharing : Type = < PerHost | PerRole >
+
 let Layout : Type =
       { specPath : I.Node -> Optional Text -> Text
+      , sharing  : Sharing
       }
 
+-- | Construct a PerHost layout (default). Existing callers that wrote
+--   `L.make { specPath = ... }` keep working bit-for-bit because the
+--   sharing field is filled in for them.
 let make
-    : Layout -> Layout
-    = \(x : Layout) -> x
+    : { specPath : I.Node -> Optional Text -> Text } -> Layout
+    = \(x : { specPath : I.Node -> Optional Text -> Text }) ->
+        { specPath = x.specPath, sharing = Sharing.PerHost }
+
+-- | Construct a PerRole layout. Use this when the specPath collapses
+--   the hostname (e.g. `${role}/${module}_spec.rb`) and you intend the
+--   spec file to be shared across every host in the role. The runner
+--   (Rakefile / CI) is then responsible for iterating hosts via
+--   TARGET_HOST or an equivalent mechanism.
+let makePerRole
+    : { specPath : I.Node -> Optional Text -> Text } -> Layout
+    = \(x : { specPath : I.Node -> Optional Text -> Text }) ->
+        { specPath = x.specPath, sharing = Sharing.PerRole }
 
 -- A common layout: <role>/<module>_spec.rb when a module is present,
--- falling back to <role>/<hostname>_spec.rb when it is not. Recommended
--- shape for the default Serverspec scaffold once you start using
--- `Spec.module_` to split a host's spec into multiple files.
+-- falling back to <role>/<hostname>_spec.rb when it is not. This is a
+-- PerRole layout: when a module label is set the path drops the hostname,
+-- so multiple hosts in the same role share `<role>/<module>_spec.rb`. The
+-- shipped Serverspec scaffold's Rakefile runs each spec for every host in
+-- the role via TARGET_HOST, so the role-shared file is the expected shape.
 let byGroupProduct
     : Layout
-    = { specPath =
-          \(n : I.Node) ->
-          \(m : Optional Text) ->
-            merge
-              { Some = \(name : Text) -> "${n.role}/${name}_spec.rb"
-              , None = "${n.role}/${n.hostname}_spec.rb"
-              }
-              m
-      }
+    = makePerRole
+        { specPath =
+            \(n : I.Node) ->
+            \(m : Optional Text) ->
+              merge
+                { Some = \(name : Text) -> "${n.role}/${name}_spec.rb"
+                , None = "${n.role}/${n.hostname}_spec.rb"
+                }
+                m
+        }
 
 -- A layout matching the ansible_spec gem convention:
 -- `spec/<group>/<module>_spec.rb` when a module label is set,
 -- `spec/<group>/<hostname>_spec.rb` otherwise. The `spec/` prefix is what
--- the shipped ansible_spec Rakefile globs against.
+-- the shipped ansible_spec Rakefile globs against. PerRole because the
+-- shipped Rakefile (`dhall/Scaffold/AnsibleSpec/Rakefile.template`)
+-- iterates the hosts file per role and reuses the same spec file for
+-- every host in that role.
 let ansibleSpec
     : Layout
-    = { specPath =
-          \(n : I.Node) ->
-          \(m : Optional Text) ->
-            merge
-              { Some = \(name : Text) -> "spec/${n.role}/${name}_spec.rb"
-              , None = "spec/${n.role}/${n.hostname}_spec.rb"
-              }
-              m
-      }
+    = makePerRole
+        { specPath =
+            \(n : I.Node) ->
+            \(m : Optional Text) ->
+              merge
+                { Some = \(name : Text) -> "spec/${n.role}/${name}_spec.rb"
+                , None = "spec/${n.role}/${n.hostname}_spec.rb"
+                }
+                m
+        }
 
 in  { Layout         = Layout
+    , Sharing        = Sharing
     , make           = make
+    , makePerRole    = makePerRole
     , byGroupProduct = byGroupProduct
     , ansibleSpec    = ansibleSpec
     }

--- a/examples/inventory-ansible-spec.dhall
+++ b/examples/inventory-ansible-spec.dhall
@@ -1,17 +1,25 @@
 -- examples/inventory-ansible-spec.dhall
--- Focused inventory for the ansible_spec scaffold example. The shipped
--- ansible_spec layout writes `spec/<group>/<module>_spec.rb`, which means
--- two hosts in the same group + module would collide on the same file.
--- Real-world ansible_spec deployments solve this at the runner level: one
--- spec file per (group, module) is parameterised over `TARGET_HOST` at
--- rake time. PanInfraSpec emits one job per host, so for now keep
--- ansible_spec inventories at one host per role; use plain Serverspec for
--- many-hosts-per-role inventories.
+-- Inventory for the ansible_spec scaffold example. The shipped
+-- ansible_spec layout writes `spec/<group>/<module>_spec.rb`, which is a
+-- PerRole layout: every host in the group shares the same spec file and
+-- the Rakefile (`Scaffold/AnsibleSpec/Rakefile.template`) iterates the
+-- hosts via TARGET_HOST. So you can list multiple hosts per role here
+-- without triggering specPath collisions.
+--
+-- Note: PerRole layouts reject `customAttributes` because those are
+-- per-host runtime values that cannot live in a role-shared spec. Use
+-- the default (PerHost) layout if you need them.
 
 let I = ../dhall/Inventory.dhall
 
 in  [ { hostname         = "web01"
       , ip               = Some "10.0.1.10"
+      , role             = "Web"
+      , tags             = [ "frontend" ]
+      , customAttributes = [] : List I.CustomAttribute
+      }
+    , { hostname         = "web02"
+      , ip               = Some "10.0.1.11"
       , role             = "Web"
       , tags             = [ "frontend" ]
       , customAttributes = [] : List I.CustomAttribute

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               paninfraspec
-version:            0.4.0.0
+version:            0.5.0.0
 synopsis:           Multi-input / multi-output compiler for infra specs (Phase 1: Serverspec)
 description:        Generates Serverspec Ruby files from per-backend Dhall preludes
                     via a Generic Semantic AST.

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -25,7 +25,7 @@ import Prettyprinter.Render.Text (renderStrict)
 
 import PanInfraSpec.Scaffold (Scaffold (..), OutputFile (..), resolveBuiltinDerivers)
 import PanInfraSpec.IR
-import PanInfraSpec.Layout (Layout (..), applySpecPath, validateLayoutPath)
+import PanInfraSpec.Layout (Layout (..), Sharing (..), applySpecPath, validateLayoutPath)
 
 -- | Schema tag for an 'AttrValue'. Used by layer-3 validation only.
 data AttrTag
@@ -999,17 +999,30 @@ emit scaffold layout ep
   | epTargetBackend ep /= "serverspec" =
       Left ("backend mismatch: expected serverspec, got " <> epTargetBackend ep)
   | otherwise = do
+      _       <- rejectCustomAttributesInPerRole (lSharing layout) (epJobs ep)
       perJob  <- traverse (formatJob layout) (epJobs ep)
-      perHost <- foldM insertNoClash Map.empty (concat perJob)
+      perHost <- foldM (insertSpec (lSharing layout)) Map.empty (concat perJob)
       let nodes  = jNode <$> epJobs ep
           extras = sStaticFiles scaffold
                 ++ sDerivedFiles scaffold nodes
                 ++ resolveBuiltinDerivers nodes (sBuiltinDerivers scaffold)
       foldM insertExtra perHost extras
   where
-    insertNoClash acc (path, content) = case Map.lookup path acc of
+    -- PerHost: any path collision is a hard error (historic behaviour).
+    -- PerRole: identical content collapses into one file (the role-shared
+    -- spec); differing content is an error because the role-shared file
+    -- cannot represent two distinct spec bodies.
+    insertSpec PerHost acc (path, content) = case Map.lookup path acc of
       Just _  -> Left ("specPath collision at " <> T.pack path
                        <> ": multiple hosts mapped to the same output file")
+      Nothing -> Right (Map.insert path content acc)
+    insertSpec PerRole acc (path, content) = case Map.lookup path acc of
+      Just existing
+        | existing == content -> Right acc
+        | otherwise           -> Left
+            ("PerRole layout: hosts sharing " <> T.pack path
+             <> " produced differing spec contents; ensure every host in the role"
+             <> " gets the same assertions or switch to a PerHost layout")
       Nothing -> Right (Map.insert path content acc)
     insertExtra acc OutputFile { ofPath = p, ofContent = c } = do
       validated <- validateLayoutPath (T.unpack p)
@@ -1017,3 +1030,16 @@ emit scaffold layout ep
         Just _  -> Left ("scaffold file " <> p
                          <> " collides with a generated spec file or another scaffold file")
         Nothing -> Right (Map.insert validated c acc)
+
+-- | PerRole layouts produce role-shared spec files; @customAttributes@ are
+-- per-host runtime values bound in a host-specific preamble, which has no
+-- meaning when the file is shared. Reject any node carrying customAttributes
+-- so the misuse fails fast rather than producing silently inconsistent output.
+rejectCustomAttributesInPerRole :: Sharing -> [Job] -> Either Text ()
+rejectCustomAttributesInPerRole PerHost _    = Right ()
+rejectCustomAttributesInPerRole PerRole jobs =
+  case [ hostname (jNode j) | j <- jobs, not (null (customAttributes (jNode j))) ] of
+    []   -> Right ()
+    h:_  -> Left
+      ("PerRole layout does not support customAttributes (host=" <> h
+       <> "); switch to a PerHost layout or remove the customAttributes")

--- a/src/PanInfraSpec/Layout.hs
+++ b/src/PanInfraSpec/Layout.hs
@@ -1,5 +1,6 @@
 module PanInfraSpec.Layout
   ( Layout (..)
+  , Sharing (..)
   , defaultLayout
   , loadLayout
   , validateLayoutPath
@@ -15,6 +16,26 @@ import qualified System.FilePath.Windows as Windows
 
 import PanInfraSpec.IR (Node (..), nodeEncoder)
 
+-- | How a layout maps inventory hosts onto output files.
+--
+-- 'PerHost' is the historic behaviour: every (node, module) pair must land
+-- on a distinct path; 'emit' fails fast if 'lSpecPath' is not injective
+-- across the inventory.
+--
+-- 'PerRole' acknowledges that a hostname-erased path
+-- (e.g. @\<role\>/\<module\>_spec.rb@) is intended to be shared across
+-- every host in the role. The emitter merges identical-content collisions
+-- into a single output file and rejects nodes that carry @customAttributes@
+-- (those are host-specific and cannot be expressed in a role-shared file).
+data Sharing = PerHost | PerRole
+  deriving stock (Eq, Show)
+
+instance Dhall.FromDhall Sharing where
+  autoWith _ = Dhall.union
+    (  (PerHost <$ Dhall.constructor "PerHost" Dhall.unit)
+    <> (PerRole <$ Dhall.constructor "PerRole" Dhall.unit)
+    )
+
 -- | How output files are laid out under @--out DIR@.
 --
 -- 'lSpecPath' is the closure decoded from the user's Dhall function of
@@ -24,10 +45,14 @@ import PanInfraSpec.IR (Node (..), nodeEncoder)
 -- (e.g. @Web/nginx_spec.rb@ + @Web/php_spec.rb@). Layouts that do not care
 -- about modules can ignore the argument.
 --
+-- 'lSharing' controls how the emitter resolves multiple jobs landing on
+-- the same path; see 'Sharing'.
+--
 -- Auxiliary file paths (Rakefile, spec_helper.rb, ...) are owned by the
 -- scaffold (see 'PanInfraSpec.Scaffold.sStaticFiles'), not by the layout.
-newtype Layout = Layout
+data Layout = Layout
   { lSpecPath :: Node -> Maybe Text -> Text
+  , lSharing  :: Sharing
   }
 
 -- | The pre-Layout-feature behaviour: hostnames at the top of @--out@.
@@ -38,6 +63,7 @@ defaultLayout = Layout
   { lSpecPath = \n m -> case m of
       Just label -> hostname n <> "_" <> label <> "_spec.rb"
       Nothing    -> hostname n <> "_spec.rb"
+  , lSharing  = PerHost
   }
 
 -- | Resolve the per-host (and optionally per-module) spec path. Forwards
@@ -46,14 +72,15 @@ applySpecPath :: Layout -> Node -> Maybe Text -> Text
 applySpecPath layout = lSpecPath layout
 
 -- | Decoder for the Layout shape:
--- @{ specPath : Node -> Optional Text -> Text }@.
+-- @{ specPath : Node -> Optional Text -> Text, sharing : < PerHost | PerRole > }@.
 decoder :: Dhall.Decoder Layout
 decoder = Dhall.record $
-  (\fn -> Layout { lSpecPath = fn })
+  Layout
     <$> Dhall.field "specPath"
           (Dhall.function nodeEncoder
              (Dhall.function (Dhall.inject :: Dhall.Encoder (Maybe Text))
                 Dhall.strictText))
+    <*> Dhall.field "sharing" Dhall.auto
 
 instance Dhall.FromDhall Layout where
   autoWith _ = decoder

--- a/test/Unit/LayoutTest.hs
+++ b/test/Unit/LayoutTest.hs
@@ -45,7 +45,7 @@ tests = testGroup "Layout"
       assertEqual "by-role" "Web/web01_spec.rb" (f (mkNode "web01" "Web"))
       assertEqual "by-role for DB" "DBPrimary/db01_spec.rb" (f (mkNode "db01" "DBPrimary"))
   , testCase "emit: rejects non-injective specPath (collision)" $
-      let layout = Layout { lSpecPath = \_ _ -> "all_specs.rb" }
+      let layout = Layout { lSpecPath = \_ _ -> "all_specs.rb", lSharing = PerHost }
           ep    = ExecutionPlan "serverspec"
                     [ Job (mkNode "web01" "Web") [pingAssertion]
                     , Job (mkNode "web02" "Web") [pingAssertion]
@@ -62,7 +62,82 @@ tests = testGroup "Layout"
       in assertLeftContains "collides"
            (emitFor scaffold defaultLayout ep)
   , testCase "loadLayout: byGroupProduct fixture works" byGroupProductLoad
+  -- PerRole sharing: role-shared spec file across multiple hosts ----------
+  , testCase "PerRole: identical content across hosts merges into one file"
+      perRoleMergesIdenticalContent
+  , testCase "PerRole: differing content across hosts is an error"
+      perRoleRejectsDifferingContent
+  , testCase "PerRole: customAttributes rejected"
+      perRoleRejectsCustomAttributes
+  , testCase "loadLayout: byGroupProduct fixture is PerRole" byGroupProductIsPerRole
   ]
+
+-- | Two hosts in the same role with the same module-tagged assertion: PerRole
+-- collapses the role-shared path (`Web/nginx_spec.rb`) into a single output.
+perRoleMergesIdenticalContent :: IO ()
+perRoleMergesIdenticalContent =
+  let layout = Layout
+        { lSpecPath = \n m -> case m of
+            Just label -> unRole (role n) <> "/" <> label <> "_spec.rb"
+            Nothing    -> unRole (role n) <> "/" <> hostname n <> "_spec.rb"
+        , lSharing  = PerRole
+        }
+      moduleLabel = Just "nginx"
+      asserts =
+        [ Assertion "command" "uname -a"
+            (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
+        ]
+      ep = ExecutionPlan "serverspec"
+             [ Job (mkNode "web01" "Web") asserts
+             , Job (mkNode "web02" "Web") asserts
+             ]
+  in case emitFor defaultServerspecScaffold layout ep of
+       Left e     -> assertFailure ("expected merge, got error: " <> T.unpack e)
+       Right outs -> do
+         assertBool "Web/nginx_spec.rb missing" $
+           Map.member "Web/nginx_spec.rb" outs
+         assertBool "no per-host nginx files should leak" $
+           not (Map.member "Web/web01_nginx_spec.rb" outs)
+
+-- | Same path, different assertion content (e.g. one host has an extra check)
+-- → PerRole cannot reconcile and must fail loudly.
+perRoleRejectsDifferingContent :: IO ()
+perRoleRejectsDifferingContent =
+  let layout = Layout
+        { lSpecPath = \n m -> case m of
+            Just label -> unRole (role n) <> "/" <> label <> "_spec.rb"
+            Nothing    -> unRole (role n) <> "/" <> hostname n <> "_spec.rb"
+        , lSharing  = PerRole
+        }
+      moduleLabel = Just "nginx"
+      base = Assertion "command" "uname -a"
+               (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
+      extra = Assertion "command" "hostname"
+                (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
+      ep = ExecutionPlan "serverspec"
+             [ Job (mkNode "web01" "Web") [base]
+             , Job (mkNode "web02" "Web") [base, extra]
+             ]
+  in assertLeftContains "differing spec contents"
+       (emitFor defaultServerspecScaffold layout ep)
+
+-- | PerRole layout + a host with non-empty customAttributes → emit refuses
+-- because per-host preamble values cannot live in a role-shared file.
+perRoleRejectsCustomAttributes :: IO ()
+perRoleRejectsCustomAttributes =
+  let layout = Layout
+        { lSpecPath = \n m -> case m of
+            Just label -> unRole (role n) <> "/" <> label <> "_spec.rb"
+            Nothing    -> unRole (role n) <> "/" <> hostname n <> "_spec.rb"
+        , lSharing  = PerRole
+        }
+      asserts = [ Assertion "command" "uname -a"
+                    (Map.fromList [("exit-status", AVNat 0)]) (Just "nginx") ]
+      noisyNode = (mkNode "web01" "Web")
+        { customAttributes = [CustomAttribute "ram" "free -k"] }
+      ep = ExecutionPlan "serverspec" [ Job noisyNode asserts ]
+  in assertLeftContains "PerRole layout does not support customAttributes"
+       (emitFor defaultServerspecScaffold layout ep)
 
 byGroupProductLoad :: IO ()
 byGroupProductLoad = do
@@ -79,6 +154,15 @@ byGroupProductLoad = do
       assertEqual "without module"
         "Web/web01_spec.rb"
         (applySpecPath l (mkNode "web01" "Web") Nothing)
+
+-- | byGroupProduct now declares itself PerRole. Make sure the Dhall fixture
+-- decoder picks that up so the role-shared spec semantics are wired through.
+byGroupProductIsPerRole :: IO ()
+byGroupProductIsPerRole = do
+  r <- loadLayout "test/Golden/by_module/layout.dhall"
+  case r of
+    Left e  -> assertFailure ("loadLayout failed: " <> T.unpack e)
+    Right l -> assertEqual "" PerRole (lSharing l)
 
 mkNode :: Text -> Text -> Node
 mkNode h r = Node h Nothing (Role r) [] []

--- a/test/Unit/ModuleSplitTest.hs
+++ b/test/Unit/ModuleSplitTest.hs
@@ -10,7 +10,7 @@ import PanInfraSpec.Emit (emitFor)
 import PanInfraSpec.Scaffold (defaultServerspecScaffold)
 import PanInfraSpec.IR hiding (Assertion)
 import qualified PanInfraSpec.IR as IR
-import PanInfraSpec.Layout (Layout (..), loadLayout)
+import PanInfraSpec.Layout (Layout (..), Sharing (..), loadLayout)
 
 tests :: TestTree
 tests = testGroup "module split"
@@ -61,6 +61,7 @@ conflictingModuleLabels =
         { lSpecPath = \n m -> case m of
             Just label -> "Web/" <> label <> "_" <> hostname n <> ".rb"
             Nothing    -> "Web/" <> hostname n <> ".rb"
+        , lSharing  = PerHost
         }
    in case emitWith layout
          [ webAssert "nginx" (Just "nginx")
@@ -77,6 +78,7 @@ conflictingModuleLabelsMixed =
         { lSpecPath = \n m -> case m of
             Just label -> "Web/" <> label <> "_" <> hostname n <> ".rb"
             Nothing    -> "Web/" <> hostname n <> ".rb"
+        , lSharing  = PerHost
         }
    in case emitWith layout
          [ webAssert "nginx" (Just "nginx")


### PR DESCRIPTION
## Summary
- Add `Sharing = < PerHost | PerRole >` to `Layout` so a layout can declare whether multiple hosts in the same role merge into one output file or must each get a distinct path.
- Update `emit` to fold identical-content collisions in PerRole mode and reject nodes with non-empty `customAttributes` (those are per-host runtime values that cannot live in a role-shared spec).
- Add `L.makePerRole` helper; mark shipped `byGroupProduct` and `ansibleSpec` as PerRole so their `${role}/${module}_spec.rb` paths now work with multi-host inventories without manual workarounds like collapsing roles into `web_general`.
- `L.make { specPath = ... }` keeps defaulting to PerHost, so existing layouts stay byte-for-byte compatible.
- Update `examples/inventory-ansible-spec.dhall` to drop the old "one host per role" caveat and add `web02`, refresh README with a PerHost vs PerRole section, and bump version to `0.5.0.0`.

## Test plan
- [x] `cabal test all` — 96 tests pass (existing 92 + 4 new PerRole unit tests covering merge, content-mismatch error, customAttributes rejection, and PerRole decoding from the byGroupProduct fixture).
- [x] e2e: ran `paninfraspec-gen` against an inventory with `web01` + `web02` + `db01` and a `module_`-tagged plan using `L.makePerRole` — `Web/nginx_spec.rb` is now produced as a single shared file (the previously failing reproduction).
- [x] e2e backward compat: `examples/inventory.dhall` + `examples/plan.dhall` with the default layout still emits `web01_spec.rb` / `web02_spec.rb` / `db01_spec.rb` unchanged.
- [x] e2e negative: PerRole layout + a host with `customAttributes` fails with `emit failed: PerRole layout does not support customAttributes (host=web01); switch to a PerHost layout or remove the customAttributes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)