### PR TITLE
Reframe README as multi-target generator; drop Goss mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,21 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Haskell](https://img.shields.io/badge/language-Haskell-5D4F85)](https://www.haskell.org/)
 
-PanInfraSpec is a Dhall front-end for [Serverspec](https://serverspec.org/).
-You describe your nodes and the assertions they should satisfy in
-[Dhall](https://dhall-lang.org/), and `paninfraspec-gen` produces the
-matching `*_spec.rb`, `spec_helper.rb`, and `Rakefile` for you. PanInfraSpec
-**does not run tests** — Serverspec still does that. It just makes the spec
-files DRY, type-checked, and easy to regenerate when your inventory changes.
+PanInfraSpec is a pluggable, multi-target generator for infrastructure
+specs. You describe your nodes and the assertions they should satisfy
+once in [Dhall](https://dhall-lang.org/), and `paninfraspec-gen` emits
+the spec files for the backend you select with `--target`.
+[Serverspec](https://serverspec.org/) is the first shipped backend
+(`*_spec.rb`, `spec_helper.rb`, `Rakefile`);
+[InSpec](https://www.chef.io/products/chef-inspec) is planned. The
+codebase is built around a backend-agnostic semantic IR, so adding a
+new backend is a new Dhall prelude plus a new emitter — existing inputs,
+the IR, and other emitters do not change. See
+[Architecture](#architecture-how-backends-plug-in).
+
+PanInfraSpec **does not run tests** — the backend's own runner still
+does that. It just makes the spec files DRY, type-checked, and easy to
+regenerate when your inventory changes.
 
 ## Install
 
@@ -305,9 +314,12 @@ Usage: paninfraspec-gen --inventory PATH --plan PATH --target BACKEND --out DIR
 - `--from-terraform-state PATH` — Terraform state JSON; `aws_instance`
   resources become nodes. Use instead of `--inventory`, not in addition to it.
 - `--plan PATH` — Dhall file returning `List Plan.Mapping`.
-- `--target BACKEND` — currently only `serverspec`. Goss, InSpec, and
-  Testinfra emitters are planned; each will ship with its own Dhall prelude
-  and become a new value here.
+- `--target BACKEND` — selects which emitter renders the spec files.
+  Backends are pluggable: today only `serverspec` is wired up, but the
+  architecture supports adding more without core changes (see
+  [Architecture](#architecture-how-backends-plug-in)). InSpec is the
+  next backend planned; it will appear here as a new value once its
+  emitter and Dhall prelude ship.
 - `--out DIR` — output directory (created if missing).
 - `--layout PATH` — optional Dhall layout file (returns `Layout.Layout`).
   When omitted, files are written flat as `<hostname>_spec.rb` (and
@@ -411,10 +423,10 @@ declared `customAttribute` — an undefined reference fails at spec runtime
 with `NameError`. Use `expand_attr` (rather than hand-writing the prefix) to
 keep typos visible in code review.
 
-## How it works
+## Architecture: how backends plug in
 
 ```
-Dhall preludes  ──►  Generic Semantic AST  ──►  per-backend emitter  ──►  out/<host>_spec.rb
+Dhall preludes  ──►  Generic Semantic IR  ──►  per-backend emitter  ──►  out/<host>_spec.rb
 ```
 
 The Dhall preludes use smart constructors so unsound combinations (e.g.
@@ -424,10 +436,14 @@ generator collects all assertions sharing a `(kind, primaryKey)` into one
 `exit-status = 0` and `exit-status = 1` for the same command), generation
 fails fast rather than emit Ruby that is guaranteed to fail at run time.
 
-The arrow above is drawn for Serverspec, but the AST and the emitter
-interface are backend-agnostic — Goss (YAML), InSpec, and Testinfra emitters
-are planned, and adding one is a new Dhall prelude plus a new emitter, with
-no changes to existing inputs.
+The arrow above is drawn for Serverspec, but the IR and the emitter
+interface are backend-agnostic. Adding a new backend is a new Dhall
+prelude plus a new emitter module — no changes to existing inputs, the
+IR, or other emitters. The dispatcher in
+[`src/PanInfraSpec/Emit.hs`](./src/PanInfraSpec/Emit.hs) routes on
+`--target`, and
+[`src/PanInfraSpec/Emit/Serverspec.hs`](./src/PanInfraSpec/Emit/Serverspec.hs)
+is the reference implementation. InSpec is the next backend planned.
 
 ## See also
 

--- a/dhall/Scaffold.dhall
+++ b/dhall/Scaffold.dhall
@@ -1,14 +1,14 @@
 -- dhall/Scaffold.dhall
 -- Execution-scaffold prelude. A Scaffold bundles the auxiliary files that
 -- accompany the per-host spec files so a runner (Serverspec, ansible_spec,
--- Goss, ...) can pick them up.
+-- ...) can pick them up.
 --
--- Backend-agnostic by design: future Goss / InSpec / Testinfra scaffolds
--- have no Rakefile concept, so this prelude does not hardcode "Rakefile" or
--- "spec_helper.rb" as fields. Instead a scaffold lists arbitrary
--- `staticFiles` (independent of inventory) and `derivedFiles` (computed
--- from the inventory). Backend-specific vocabulary lives in the shipped
--- prelude instances under `Scaffold/`.
+-- Backend-agnostic by design: a future InSpec scaffold has no Rakefile
+-- concept, so this prelude does not hardcode "Rakefile" or "spec_helper.rb"
+-- as fields. Instead a scaffold lists arbitrary `staticFiles` (independent
+-- of inventory) and `derivedFiles` (computed from the inventory).
+-- Backend-specific vocabulary lives in the shipped prelude instances under
+-- `Scaffold/`.
 --
 -- File contents are plain `Text`. Use Dhall's `./path as Text` import to
 -- pull a Rakefile / spec_helper.rb body from a sibling text file rather

--- a/docs/scaffold.md
+++ b/docs/scaffold.md
@@ -3,9 +3,9 @@
 A *scaffold* owns the auxiliary files that wrap the per-host spec files —
 the Rakefile, the spec helper, and any inventory-derived inventory files
 (e.g. ansible_spec's `hosts` and `site.yml`). A scaffold is decoupled from
-the *target backend* (`--target serverspec`, future `--target goss`,
-etc.) and decoupled from the *output layout* (`--layout`), so the three
-axes compose freely.
+the *target backend* (`--target serverspec`, future `--target inspec`)
+and decoupled from the *output layout* (`--layout`), so the three axes
+compose freely.
 
 PanInfraSpec ships two scaffolds out of the box:
 

--- a/src/PanInfraSpec/Scaffold.hs
+++ b/src/PanInfraSpec/Scaffold.hs
@@ -49,8 +49,8 @@ instance Dhall.FromDhall BuiltinDeriver where
 
 -- | Execution scaffold loaded from a Dhall file (or supplied as the built-in
 -- 'defaultServerspecScaffold'). The scaffold owns the auxiliary files that
--- wrap the per-host spec files so a runner (Serverspec, ansible_spec,
--- Goss, ...) can pick them up.
+-- wrap the per-host spec files so a runner (Serverspec, ansible_spec, ...)
+-- can pick them up.
 --
 -- 'sStaticFiles' are inventory-independent files (Rakefile / spec_helper.rb
 -- in the Serverspec case). 'sDerivedFiles' is a Dhall function applied to
@@ -63,8 +63,9 @@ instance Dhall.FromDhall BuiltinDeriver where
 -- 'resolveBuiltinDerivers'.
 --
 -- Backend-specific vocabulary (the fact that Serverspec wants a Rakefile,
--- that Goss wants a @goss.yaml@, ...) lives in the shipped Dhall scaffold
--- preludes under @dhall/Scaffold/@, not in this Haskell type.
+-- that a future InSpec scaffold would want its own profile layout, ...)
+-- lives in the shipped Dhall scaffold preludes under @dhall/Scaffold/@, not
+-- in this Haskell type.
 data Scaffold = Scaffold
   { sName            :: Text
   , sStaticFiles     :: [OutputFile]


### PR DESCRIPTION
## Summary
- Rewrite the README opening paragraph to position PanInfraSpec as a pluggable, multi-target spec generator with Serverspec as the first shipped backend and InSpec planned, instead of a single-purpose "Dhall front-end for Serverspec".
- Update the `--target BACKEND` CLI reference to emphasise pluggability and link to the new architecture section.
- Rename "How it works" to "Architecture: how backends plug in", refresh the diagram (AST → IR), and link the dispatcher (`src/PanInfraSpec/Emit.hs`) and reference emitter (`src/PanInfraSpec/Emit/Serverspec.hs`) so contributors can find the extension points.
- Drop Goss mentions from README, `dhall/Scaffold.dhall`, `docs/scaffold.md`, and `src/PanInfraSpec/Scaffold.hs` comments — Goss is out of scope (plain Dhall already covers that use case). InSpec stays as the only "planned" backend.
- Closes #41.

## Notes
- No code/behaviour changes — this is documentation and code-comment only.
- `test/Unit/ValidateTest.hs` still uses `"goss"` as an unknown-backend sentinel for the dispatcher reject path. That is consistent with Goss being permanently unsupported, so it is left alone.

## Test plan
- [x] `cabal build all` succeeds.
- [x] `cabal test` passes (92/92).
- [ ] Reviewer eyeballs the rendered README on GitHub: opening paragraph reads as multi-target, `--target` description reflects extensibility, internal anchor `#architecture-how-backends-plug-in` resolves, and no Goss mentions remain in user-facing docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)