### PR TITLE
Allow customAttributes in PerRole when consistent across hosts

### DIFF
--- a/dhall/Layout.dhall
+++ b/dhall/Layout.dhall
@@ -21,8 +21,12 @@
 --            role are merged into a single output file when their generated
 --            content matches; per-host runs are expected to come from the
 --            scaffold-side runner (e.g. ansible_spec's Rakefile sets
---            TARGET_HOST per host). `customAttributes` are host-specific and
---            therefore rejected at emit time in PerRole mode.
+--            TARGET_HOST per host). `customAttributes` are allowed as long as
+--            every host in the role declares the same set (matching `name`
+--            and `command`); the preamble runs against each host's Specinfra
+--            backend at runtime, so a role-shared file is correct. Divergent
+--            customAttributes within a role surface as a content mismatch
+--            at emit time.
 
 let I = ./Inventory.dhall
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ nix run github:ikaro1192/PanInfraSpec -- \
 nix profile install github:ikaro1192/PanInfraSpec
 
 # Pin to a specific release
-nix profile install github:ikaro1192/PanInfraSpec/v0.5.0.0
+nix profile install github:ikaro1192/PanInfraSpec/v0.5.1.0
 ```
 
 Supported systems: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`,
@@ -98,14 +98,14 @@ upgrade tracking).
 
 ```sh
 docker run --rm -v "$PWD":/work \
-  ghcr.io/ikaro1192/paninfraspec-gen:0.4 \
+  ghcr.io/ikaro1192/paninfraspec-gen:0.5 \
   --inventory examples/inventory.dhall \
   --plan      examples/plan.dhall \
   --target    serverspec \
   --out       /work/out
 ```
 
-Each release publishes `latest`, the full version (`0.5.0.0`), and pin-friendly
+Each release publishes `latest`, the full version (`0.5.1.0`), and pin-friendly
 `major.minor` / `major.minor.patch` tags to
 [ghcr.io/ikaro1192/paninfraspec-gen](https://github.com/ikaro1192/PanInfraSpec/pkgs/container/paninfraspec-gen).
 Built for `linux/amd64` and `linux/arm64`. The image only generates spec

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -21,16 +21,21 @@ output files:
 
 - **PerHost** (default; `L.make { specPath = ... }`) — every (node, module)
   pair must map to a distinct file. The generator fails fast if `specPath`
-  is non-injective. Required when nodes carry `customAttributes`, since
-  those are per-host runtime values rendered into a host-specific preamble.
+  is non-injective. Each host gets its own preamble, so per-host
+  `customAttributes` are unrestricted.
 - **PerRole** (`L.makePerRole { ... }`, also `L.byGroupProduct`,
   `L.ansibleSpec`) — a `specPath` that drops the hostname (e.g.
   `${role}/${module}_spec.rb`) is intended to be a role-shared file.
   Multiple hosts in the same role merge into a single file when their
   generated content matches; differing content fails. Per-host execution
   is expected to come from the runner (the shipped ansible_spec Rakefile
-  iterates the inventory and sets `TARGET_HOST` per host). PerRole layouts
-  reject any node with non-empty `customAttributes`.
+  iterates the inventory and sets `TARGET_HOST` per host).
+  `customAttributes` are allowed as long as every host in the role declares
+  the same set (matching `name` and `command`) — the rendered preamble uses
+  `Specinfra.backend.run_command(...)`, which executes against each host's
+  backend at runtime. If two hosts in the same role need different
+  `customAttributes`, emit fails with a content-mismatch error: align them
+  or split the role.
 
 ## Rolling your own
 

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               paninfraspec
-version:            0.5.0.0
+version:            0.5.1.0
 synopsis:           Multi-input / multi-output compiler for infra specs (Phase 1: Serverspec)
 description:        Generates Serverspec Ruby files from per-backend Dhall preludes
                     via a Generic Semantic AST.

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -999,7 +999,6 @@ emit scaffold layout ep
   | epTargetBackend ep /= "serverspec" =
       Left ("backend mismatch: expected serverspec, got " <> epTargetBackend ep)
   | otherwise = do
-      _       <- rejectCustomAttributesInPerRole (lSharing layout) (epJobs ep)
       perJob  <- traverse (formatJob layout) (epJobs ep)
       perHost <- foldM (insertSpec (lSharing layout)) Map.empty (concat perJob)
       let nodes  = jNode <$> epJobs ep
@@ -1011,7 +1010,12 @@ emit scaffold layout ep
     -- PerHost: any path collision is a hard error (historic behaviour).
     -- PerRole: identical content collapses into one file (the role-shared
     -- spec); differing content is an error because the role-shared file
-    -- cannot represent two distinct spec bodies.
+    -- cannot represent two distinct spec bodies. customAttributes are
+    -- expanded into a preamble that runs against each host's Specinfra
+    -- backend at runtime, so a role-shared file is fine as long as every
+    -- host in the role declares the same customAttributes (same name and
+    -- command, in the same order). Divergence shows up here as differing
+    -- content.
     insertSpec PerHost acc (path, content) = case Map.lookup path acc of
       Just _  -> Left ("specPath collision at " <> T.pack path
                        <> ": multiple hosts mapped to the same output file")
@@ -1022,7 +1026,8 @@ emit scaffold layout ep
         | otherwise           -> Left
             ("PerRole layout: hosts sharing " <> T.pack path
              <> " produced differing spec contents; ensure every host in the role"
-             <> " gets the same assertions or switch to a PerHost layout")
+             <> " gets the same assertions and the same customAttributes"
+             <> " (matching name and command), or switch to a PerHost layout")
       Nothing -> Right (Map.insert path content acc)
     insertExtra acc OutputFile { ofPath = p, ofContent = c } = do
       validated <- validateLayoutPath (T.unpack p)
@@ -1030,16 +1035,3 @@ emit scaffold layout ep
         Just _  -> Left ("scaffold file " <> p
                          <> " collides with a generated spec file or another scaffold file")
         Nothing -> Right (Map.insert validated c acc)
-
--- | PerRole layouts produce role-shared spec files; @customAttributes@ are
--- per-host runtime values bound in a host-specific preamble, which has no
--- meaning when the file is shared. Reject any node carrying customAttributes
--- so the misuse fails fast rather than producing silently inconsistent output.
-rejectCustomAttributesInPerRole :: Sharing -> [Job] -> Either Text ()
-rejectCustomAttributesInPerRole PerHost _    = Right ()
-rejectCustomAttributesInPerRole PerRole jobs =
-  case [ hostname (jNode j) | j <- jobs, not (null (customAttributes (jNode j))) ] of
-    []   -> Right ()
-    h:_  -> Left
-      ("PerRole layout does not support customAttributes (host=" <> h
-       <> "); switch to a PerHost layout or remove the customAttributes")

--- a/src/PanInfraSpec/Layout.hs
+++ b/src/PanInfraSpec/Layout.hs
@@ -25,8 +25,12 @@ import PanInfraSpec.IR (Node (..), nodeEncoder)
 -- 'PerRole' acknowledges that a hostname-erased path
 -- (e.g. @\<role\>/\<module\>_spec.rb@) is intended to be shared across
 -- every host in the role. The emitter merges identical-content collisions
--- into a single output file and rejects nodes that carry @customAttributes@
--- (those are host-specific and cannot be expressed in a role-shared file).
+-- into a single output file. @customAttributes@ are allowed as long as
+-- every host in the role declares the same set (matching @name@ and
+-- @command@); the rendered preamble runs against each host's Specinfra
+-- backend at runtime, so a role-shared file is correct. Divergent
+-- customAttributes between hosts in the same role surface as a
+-- differing-content error.
 data Sharing = PerHost | PerRole
   deriving stock (Eq, Show)
 

--- a/test/Unit/LayoutTest.hs
+++ b/test/Unit/LayoutTest.hs
@@ -67,8 +67,10 @@ tests = testGroup "Layout"
       perRoleMergesIdenticalContent
   , testCase "PerRole: differing content across hosts is an error"
       perRoleRejectsDifferingContent
-  , testCase "PerRole: customAttributes rejected"
-      perRoleRejectsCustomAttributes
+  , testCase "PerRole: identical customAttributes across hosts share one preamble"
+      perRoleAcceptsConsistentCustomAttributes
+  , testCase "PerRole: divergent customAttributes across hosts is an error"
+      perRoleRejectsDivergingCustomAttributes
   , testCase "loadLayout: byGroupProduct fixture is PerRole" byGroupProductIsPerRole
   ]
 
@@ -121,22 +123,65 @@ perRoleRejectsDifferingContent =
   in assertLeftContains "differing spec contents"
        (emitFor defaultServerspecScaffold layout ep)
 
--- | PerRole layout + a host with non-empty customAttributes → emit refuses
--- because per-host preamble values cannot live in a role-shared file.
-perRoleRejectsCustomAttributes :: IO ()
-perRoleRejectsCustomAttributes =
+-- | PerRole layout + every host in the role declaring the same
+-- customAttributes → emit collapses the role-shared spec into one file
+-- whose preamble appears exactly once. The preamble's
+-- @Specinfra.backend.run_command(...)@ resolves against each host's own
+-- backend at runtime, so a single shared file is correct.
+perRoleAcceptsConsistentCustomAttributes :: IO ()
+perRoleAcceptsConsistentCustomAttributes =
   let layout = Layout
         { lSpecPath = \n m -> case m of
             Just label -> unRole (role n) <> "/" <> label <> "_spec.rb"
             Nothing    -> unRole (role n) <> "/" <> hostname n <> "_spec.rb"
         , lSharing  = PerRole
         }
-      asserts = [ Assertion "command" "uname -a"
-                    (Map.fromList [("exit-status", AVNat 0)]) (Just "nginx") ]
-      noisyNode = (mkNode "web01" "Web")
+      moduleLabel = Just "nginx"
+      asserts =
+        [ Assertion "command" "uname -a"
+            (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
+        ]
+      cas      = [CustomAttribute "ram" "free -k"]
+      mkHost h = (mkNode h "Web") { customAttributes = cas }
+      ep       = ExecutionPlan "serverspec"
+                   [ Job (mkHost "web01") asserts
+                   , Job (mkHost "web02") asserts
+                   ]
+  in case emitFor defaultServerspecScaffold layout ep of
+       Left e     -> assertFailure ("expected merge, got error: " <> T.unpack e)
+       Right outs -> case Map.lookup "Web/nginx_spec.rb" outs of
+         Nothing      -> assertFailure "Web/nginx_spec.rb missing"
+         Just content -> do
+           assertBool "preamble missing" $
+             "paninfraspec_ram = Specinfra.backend.run_command('free -k').stdout.strip"
+               `T.isInfixOf` content
+           assertEqual "preamble must appear exactly once" 1 $
+             T.count "paninfraspec_ram =" content
+
+-- | PerRole layout + two hosts in the same role declaring different
+-- customAttributes → emit fails because the rendered preamble differs and
+-- the role-shared file cannot represent both. The new error message points
+-- at customAttributes so the operator knows what to align.
+perRoleRejectsDivergingCustomAttributes :: IO ()
+perRoleRejectsDivergingCustomAttributes =
+  let layout = Layout
+        { lSpecPath = \n m -> case m of
+            Just label -> unRole (role n) <> "/" <> label <> "_spec.rb"
+            Nothing    -> unRole (role n) <> "/" <> hostname n <> "_spec.rb"
+        , lSharing  = PerRole
+        }
+      moduleLabel = Just "nginx"
+      asserts =
+        [ Assertion "command" "uname -a"
+            (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
+        ]
+      hostA = (mkNode "web01" "Web")
         { customAttributes = [CustomAttribute "ram" "free -k"] }
-      ep = ExecutionPlan "serverspec" [ Job noisyNode asserts ]
-  in assertLeftContains "PerRole layout does not support customAttributes"
+      hostB = (mkNode "web02" "Web")
+        { customAttributes = [CustomAttribute "ram" "free -m"] }
+      ep = ExecutionPlan "serverspec"
+             [ Job hostA asserts, Job hostB asserts ]
+  in assertLeftContains "customAttributes"
        (emitFor defaultServerspecScaffold layout ep)
 
 byGroupProductLoad :: IO ()


### PR DESCRIPTION
## Summary
- Drop the blanket rejection of `customAttributes` in PerRole layouts. The preamble uses `Specinfra.backend.run_command(...)`, which runs against each host's own backend at runtime, so a role-shared spec file is correct whenever every host in the role declares the same customAttributes set.
- Lean on the existing PerRole content-equality check in `insertSpec` to catch divergence; widen its error message to call out customAttributes as a likely cause.
- Refresh `Layout.hs` / `dhall/Layout.dhall` / `docs/layout.md` to document the new semantics.
- Replace the unit test that pinned the old "always reject" behavior with two new cases: identical customAttributes across hosts share one preamble, divergent customAttributes fail with the new message.
- Bump version to 0.5.1.0 and update the Docker tag pin (`:0.4` → `:0.5`) in the install docs.

## Test plan
- [x] `cabal build`
- [x] `cabal test` — all 93 tests pass, including the two new PerRole + customAttributes cases
- [x] e2e: `paninfraspec-gen --inventory examples/inventory.dhall --plan examples/plan.dhall --target serverspec --out … --layout test/Golden/by_module/layout.dhall` — succeeds where it previously failed; generated `DBPrimary/db01_spec.rb` contains the `paninfraspec_total_ram_kb = Specinfra.backend.run_command(...)` preamble.

🤖 Generated with [Claude Code](https://claude.com/claude-code)