### PR TITLE
Add --version/-V flag to paninfraspec-gen CLI

### DIFF
--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -59,6 +59,10 @@ library
     , PanInfraSpec.SoT
     , PanInfraSpec.SoT.Terraform
     , PanInfraSpec.CLI
+  autogen-modules:
+      Paths_paninfraspec
+  other-modules:
+      Paths_paninfraspec
 
 executable paninfraspec-gen
   import:           deps

--- a/src/PanInfraSpec/CLI.hs
+++ b/src/PanInfraSpec/CLI.hs
@@ -16,11 +16,14 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.IO as TIO
+import Data.Version (showVersion)
 import Options.Applicative
 import System.Directory (createDirectoryIfMissing)
 import System.Exit (ExitCode (..))
 import System.FilePath (takeDirectory, (</>))
 import System.IO (hPutStrLn, stderr)
+
+import qualified Paths_paninfraspec as Paths
 
 import PanInfraSpec.Dhall (loadInventory, loadPlan, validate)
 import PanInfraSpec.DumpPlan (dumpPlan)
@@ -123,8 +126,15 @@ parser = Options
        <> help "Print the resolved ExecutionPlan as a tree and exit (no output written)"
         )
 
+versionOption :: Parser (a -> a)
+versionOption = infoOption (showVersion Paths.version)
+  ( long "version"
+ <> short 'V'
+ <> help "Print version and exit"
+  )
+
 parserInfo :: ParserInfo Options
-parserInfo = info (parser <**> helper)
+parserInfo = info (parser <**> helper <**> versionOption)
   ( fullDesc
  <> progDesc "Generate Serverspec specs from a Dhall inventory + plan"
  <> header   "paninfraspec-gen — multi-input / multi-output infra spec compiler"


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` flag that prints the version and exits.
- Version string is sourced from the cabal-generated `Paths_paninfraspec.version`, so it tracks the cabal file's `version:` field automatically.
- Register `Paths_paninfraspec` as `autogen-modules` / `other-modules` in the library stanza.

## Test plan
- [x] `cabal build` succeeds
- [x] `cabal test` passes (93/93)
- [x] `paninfraspec-gen --version` prints `0.5.1.0`
- [x] `paninfraspec-gen -V` prints `0.5.1.0`
- [x] `paninfraspec-gen --help` lists the new flag and does not require other options

🤖 Generated with [Claude Code](https://claude.com/claude-code)