### PR TITLE
Split IR.hs into Inventory/Selector/Assertion submodules

### DIFF
--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -49,6 +49,9 @@ library
   hs-source-dirs:   src
   exposed-modules:
       PanInfraSpec.IR
+    , PanInfraSpec.IR.Inventory
+    , PanInfraSpec.IR.Selector
+    , PanInfraSpec.IR.Assertion
     , PanInfraSpec.Dhall
     , PanInfraSpec.Layout
     , PanInfraSpec.Resolve
@@ -81,6 +84,7 @@ test-suite paninfraspec-test
     , Unit.EmitCustomAttributesTest
     , Unit.ScaffoldTest
     , Unit.ModuleSplitTest
+    , Unit.IR.SplitTest
     , Roundtrip.DhallEncodingTest
     , Property.EmitTest
     , Synth.HundredHostsTest

--- a/src/PanInfraSpec/IR.hs
+++ b/src/PanInfraSpec/IR.hs
@@ -1,3 +1,14 @@
+-- | Backend-agnostic semantic IR.
+--
+-- This module is a re-export façade over three submodules split by
+-- backend-affinity:
+--
+-- * "PanInfraSpec.IR.Inventory" — completely backend-agnostic (nodes / roles).
+-- * "PanInfraSpec.IR.Selector" — backend-agnostic in shape.
+-- * "PanInfraSpec.IR.Assertion" — carries 'aKind' values whose vocabulary is
+--   governed by the chosen backend's schema (today only Serverspec).
+--
+-- Every external consumer should keep importing @PanInfraSpec.IR@ unchanged.
 module PanInfraSpec.IR
   ( Role (..)
   , CustomAttribute (..)
@@ -16,277 +27,22 @@ module PanInfraSpec.IR
   , nodeEncoder
   ) where
 
-import Data.Functor.Contravariant (contramap, (>$<))
-import Data.Functor.Contravariant.Divisible (divided)
-import Data.Map.Strict (Map)
-import Data.String (IsString)
-import Data.Text (Text)
-import Numeric.Natural (Natural)
-import GHC.Generics (Generic)
-
-import qualified Dhall
-
--- | An organisation-defined role label. Kept as a Text wrapper because
--- vocabularies vary (Web / DBPrimary / cache / …).
-newtype Role = Role { unRole :: Text }
-  deriving stock   (Generic)
-  deriving newtype (Show, Eq, Ord, IsString, Dhall.FromDhall)
-
--- | A per-host shell command whose stdout becomes a Ruby variable bound at
--- the top of the generated spec file (as @paninfraspec_<caName>@). Plans can
--- then reference that value via 'AttrLeaf.ALRubyExpr', enabling
--- host-dependent expected values (e.g., "innodb_buffer_pool_size must be at
--- least 70% of the host's total RAM"). Mirrors the Dhall record
--- @{ name : Text, command : Text }@ in @dhall/Inventory.dhall@.
-data CustomAttribute = CustomAttribute
-  { caName    :: Text
-  , caCommand :: Text
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall CustomAttribute where
-  autoWith _ = Dhall.record $
-    CustomAttribute
-      <$> Dhall.field "name"    Dhall.auto
-      <*> Dhall.field "command" Dhall.auto
-
--- | One inventory entry. Mirrors @dhall/Inventory.dhall@'s @Node@.
-data Node = Node
-  { hostname         :: Text
-  , ip               :: Maybe Text
-  , role             :: Role
-  , tags             :: [Text]
-  , customAttributes :: [CustomAttribute]
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall Node where
-  autoWith _ = Dhall.record $
-    Node
-      <$> Dhall.field "hostname"         Dhall.auto
-      <*> Dhall.field "ip"               Dhall.auto
-      <*> Dhall.field "role"             Dhall.auto
-      <*> Dhall.field "tags"             Dhall.auto
-      <*> Dhall.field "customAttributes" Dhall.auto
-
--- | Encoder for 'Role'. Wraps Text via the Role newtype unwrap. Needed so a
--- Dhall function value @\\(n : Inventory.Node) -> ...@ can be applied
--- host-by-host: dhall must inject the Haskell 'Node' back into a Dhall record
--- before evaluating the user's function. See 'PanInfraSpec.Layout'.
-roleEncoder :: Dhall.Encoder Role
-roleEncoder = contramap unRole Dhall.inject
-
--- | Encoder for 'CustomAttribute'. Mirrors the Dhall record
--- @{ name : Text, command : Text }@ so a user-written
--- @\\(n : Inventory.Node) -> ...@ can reach @n.customAttributes@ during
--- Layout evaluation if it ever wants to.
-customAttributeEncoder :: Dhall.Encoder CustomAttribute
-customAttributeEncoder = Dhall.recordEncoder $
-  splay >$< (Dhall.encodeFieldWith "name"    Dhall.inject
-       `divided`  Dhall.encodeFieldWith "command" Dhall.inject)
-  where
-    splay c = (caName c, caCommand c)
-
--- | 'ToDhall' instance for 'CustomAttribute' lets @Dhall.inject@ derive an
--- encoder for @[CustomAttribute]@ when building 'nodeEncoder'.
-instance Dhall.ToDhall CustomAttribute where
-  injectWith _ = customAttributeEncoder
-
--- | 'ToDhall' instance for 'Node' lets @Dhall.inject@ derive an encoder for
--- @[Node]@. Needed by 'PanInfraSpec.Scaffold' so a Dhall function value
--- @\\(nodes : List Inventory.Node) -> ...@ can be applied to the resolved
--- inventory at emit time.
-instance Dhall.ToDhall Node where
-  injectWith _ = nodeEncoder
-
--- | Encoder for 'Node'. The field set and types must match
--- @dhall/Inventory.dhall@'s @Node@ exactly, otherwise the user's
--- @\\(n : Inventory.Node) -> ...@ will not type-check at evaluation time.
---
--- 'Dhall.RecordEncoder' is not a 'Semigroup' in dhall-1.42, so we build the
--- record by composing field encoders through 'Divisible' ('divided') and
--- splaying 'Node' into a right-nested tuple.
-nodeEncoder :: Dhall.Encoder Node
-nodeEncoder = Dhall.recordEncoder $
-  splay >$< (Dhall.encodeFieldWith "hostname" Dhall.inject
-       `divided` (Dhall.encodeFieldWith "ip" Dhall.inject
-       `divided` (Dhall.encodeFieldWith "role" roleEncoder
-       `divided` (Dhall.encodeFieldWith "tags" Dhall.inject
-       `divided`  Dhall.encodeFieldWith "customAttributes" Dhall.inject))))
-  where
-    splay n = (hostname n, (ip n, (role n, (tags n, customAttributes n))))
-
--- | Comparison operator for 'AVCompare'. Mirrors the Dhall union
--- @< Lt | Le | Gt | Ge | Eq | Match >@. Used for matchers like
--- @validity_in_days should be > 30@ and @value should match /pattern/@.
-data CompareOp = OpLt | OpLe | OpGt | OpGe | OpEq | OpMatch
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall CompareOp where
-  autoWith _ = Dhall.union
-    (  (OpLt    <$ Dhall.constructor "Lt"    Dhall.unit)
-    <> (OpLe    <$ Dhall.constructor "Le"    Dhall.unit)
-    <> (OpGt    <$ Dhall.constructor "Gt"    Dhall.unit)
-    <> (OpGe    <$ Dhall.constructor "Ge"    Dhall.unit)
-    <> (OpEq    <$ Dhall.constructor "Eq"    Dhall.unit)
-    <> (OpMatch <$ Dhall.constructor "Match" Dhall.unit)
-    )
-
--- | Scalar leaf carried inside compound 'AttrValue' constructors
--- ('AVList', 'AVRecord', 'AVCompare'). Dhall lacks recursive types, so the
--- nested element type is a separate, non-recursive union (the same trick
--- used for 'Selector' boolean composition).
-data AttrLeaf
-  = ALText     Text
-  | ALNat      Natural
-  | ALBool     Bool
-  | ALSymbol   Text
-  | ALRegex    Text   -- ^ Ruby regex literal payload (without surrounding @/.../@).
-  | ALRubyExpr Text   -- ^ Bare Ruby expression. Emitted unquoted so the value
-                      -- can flow into a matcher that compares against a Ruby
-                      -- variable or arithmetic expression (e.g.
-                      -- @paninfraspec_total_ram_kb.to_i * 1024 * 70 \/ 100@).
-                      -- Unlike 'ALText', no escaping or surrounding quotes
-                      -- are added — the user is asserting "this is Ruby".
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall AttrLeaf where
-  autoWith _ = Dhall.union
-    (  (ALText     <$> Dhall.constructor "ALText"     Dhall.auto)
-    <> (ALNat      <$> Dhall.constructor "ALNat"      Dhall.auto)
-    <> (ALBool     <$> Dhall.constructor "ALBool"     Dhall.auto)
-    <> (ALSymbol   <$> Dhall.constructor "ALSymbol"   Dhall.auto)
-    <> (ALRegex    <$> Dhall.constructor "ALRegex"    Dhall.auto)
-    <> (ALRubyExpr <$> Dhall.constructor "ALRubyExpr" Dhall.auto)
-    )
-
--- | Attribute value carried inside an 'Assertion'. Mirrors the Dhall union
--- declared in @dhall/Serverspec.dhall@. The compound constructors
--- ('AVList', 'AVRecord', 'AVCompare') carry 'AttrLeaf' instead of
--- 'AttrValue' to stay within Dhall's non-recursive type system.
-data AttrValue
-  = AVText    Text
-  | AVNat     Natural
-  | AVBool    Bool
-  | AVSymbol  Text
-  | AVList    [AttrLeaf]
-  | AVRecord  (Map Text AttrLeaf)
-  | AVCompare CompareOp AttrLeaf
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall AttrValue where
-  autoWith _ = Dhall.union
-    (  (AVText    <$> Dhall.constructor "AVText"    Dhall.auto)
-    <> (AVNat     <$> Dhall.constructor "AVNat"     Dhall.auto)
-    <> (AVBool    <$> Dhall.constructor "AVBool"    Dhall.auto)
-    <> (AVSymbol  <$> Dhall.constructor "AVSymbol"  Dhall.auto)
-    <> (AVList    <$> Dhall.constructor "AVList"    Dhall.auto)
-    <> (AVRecord  <$> Dhall.constructor "AVRecord"  Dhall.auto)
-    <> (mkCompare <$> Dhall.constructor "AVCompare" cmpRecord)
-    )
-    where
-      mkCompare (op, v) = AVCompare op v
-      cmpRecord = Dhall.record $
-        (,) <$> Dhall.field "op"    Dhall.auto
-            <*> Dhall.field "value" Dhall.auto
-
--- | Generic Semantic AST element. The pair @(aKind, aPrimaryKey)@ is the
--- groupBy key the emitter uses to fold multiple state assertions for the same
--- resource into one @describe@ block.
---
--- @aAttrs@ comes from Dhall as @List { mapKey, mapValue }@ via 'toMap', so
--- duplicate keys cannot arise from the smart constructors. A user hand-writing
--- the underlying record could produce duplicates; 'Map.fromList' is
--- last-write-wins. Layer 3 (the emitter) catches unknown keys; silent merge of
--- duplicate keys is acceptable for Phase 1.
---
--- @aModule@ is an optional product label set by @Spec.module "name" […]@ in
--- the Dhall plan. The emitter partitions merged groups by this label so a
--- single host can produce multiple spec files (e.g. @Web/nginx_spec.rb@ and
--- @Web/php_spec.rb@). 'Nothing' means "no module label" — those assertions
--- land in the layout's default file. Module-aware splitting requires a v2
--- 'PanInfraSpec.Layout.Layout'; v1 layouts collapse all modules into one
--- file (which is the pre-module behaviour, byte-for-byte).
-data Assertion = Assertion
-  { aKind       :: Text
-  , aPrimaryKey :: Text
-  , aAttrs      :: Map Text AttrValue
-  , aModule     :: Maybe Text
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall Assertion where
-  autoWith _ = Dhall.record $
-    Assertion
-      <$> Dhall.field "kind"       Dhall.auto
-      <*> Dhall.field "primaryKey" Dhall.auto
-      <*> Dhall.field "attrs"      Dhall.auto
-      <*> Dhall.field "module"     Dhall.auto
-
--- | Selects which nodes a 'Mapping' applies to. AND/OR/NOT are added in
--- Phase 3 as additive constructors used for Haskell-side composition (e.g.,
--- CLI filter chaining). They have no Dhall surface because Dhall lacks
--- recursive types; the four base constructors below are the full set
--- reachable from a Dhall plan.
-data Selector
-  = SelAll
-  | SelRole Role
-  | SelTag  Text
-  | SelHost Text
-  | SelAnd  [Selector]
-  | SelOr   [Selector]
-  | SelNot  Selector
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall Selector where
-  autoWith _ = Dhall.union
-    (  (SelAll  <$  Dhall.constructor "SelAll"  Dhall.unit)
-    <> (SelRole <$> Dhall.constructor "SelRole" Dhall.auto)
-    <> (SelTag  <$> Dhall.constructor "SelTag"  Dhall.auto)
-    <> (SelHost <$> Dhall.constructor "SelHost" Dhall.auto)
-    -- AND / OR / NOT are not exposed via Dhall; Dhall lacks recursive types.
-    -- Constructed Haskell-side only.
-    )
-
-data Mapping = Mapping
-  { mSelector   :: Selector
-  , mAssertions :: [Assertion]
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall Mapping where
-  autoWith _ = Dhall.record $
-    Mapping
-      <$> Dhall.field "selector"   Dhall.auto
-      <*> Dhall.field "assertions" Dhall.auto
-
--- | The whole loaded plan file. The @targetBackend@ field is forwarded from
--- the per-backend Dhall prelude (e.g., @Serverspec.dhall@) and lets the CLI
--- assert that @--target@ matches the prelude the user actually imported.
-data PlanFile = PlanFile
-  { pfTargetBackend :: Text
-  , pfMappings      :: [Mapping]
-  }
-  deriving stock (Show, Eq, Generic)
-
-instance Dhall.FromDhall PlanFile where
-  autoWith _ = Dhall.record $
-    PlanFile
-      <$> Dhall.field "targetBackend" Dhall.auto
-      <*> Dhall.field "mappings"      Dhall.auto
-
--- | A node and the assertions resolved for it. Internal IR only; not loaded
--- from Dhall.
-data Job = Job
-  { jNode       :: Node
-  , jAssertions :: [Assertion]
-  }
-  deriving stock (Show, Eq, Generic)
-
--- | The fully resolved plan handed to an emitter. @epTargetBackend@ drives
--- emitter dispatch.
-data ExecutionPlan = ExecutionPlan
-  { epTargetBackend :: Text
-  , epJobs          :: [Job]
-  }
-  deriving stock (Show, Eq, Generic)
+import PanInfraSpec.IR.Inventory
+  ( Role (..)
+  , CustomAttribute (..)
+  , Node (..)
+  , roleEncoder
+  , customAttributeEncoder
+  , nodeEncoder
+  )
+import PanInfraSpec.IR.Selector  (Selector (..))
+import PanInfraSpec.IR.Assertion
+  ( CompareOp (..)
+  , AttrLeaf (..)
+  , AttrValue (..)
+  , Assertion (..)
+  , Mapping (..)
+  , PlanFile (..)
+  , Job (..)
+  , ExecutionPlan (..)
+  )

--- a/src/PanInfraSpec/IR/Assertion.hs
+++ b/src/PanInfraSpec/IR/Assertion.hs
@@ -1,0 +1,174 @@
+module PanInfraSpec.IR.Assertion
+  ( CompareOp (..)
+  , AttrLeaf (..)
+  , AttrValue (..)
+  , Assertion (..)
+  , Mapping (..)
+  , PlanFile (..)
+  , Job (..)
+  , ExecutionPlan (..)
+  ) where
+
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+import Numeric.Natural (Natural)
+import GHC.Generics (Generic)
+
+import qualified Dhall
+
+import PanInfraSpec.IR.Inventory (Node)
+import PanInfraSpec.IR.Selector  (Selector)
+
+-- | Comparison operator for 'AVCompare'. Mirrors the Dhall union
+-- @< Lt | Le | Gt | Ge | Eq | Match >@. Used for matchers like
+-- @validity_in_days should be > 30@ and @value should match /pattern/@.
+data CompareOp = OpLt | OpLe | OpGt | OpGe | OpEq | OpMatch
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall CompareOp where
+  autoWith _ = Dhall.union
+    (  (OpLt    <$ Dhall.constructor "Lt"    Dhall.unit)
+    <> (OpLe    <$ Dhall.constructor "Le"    Dhall.unit)
+    <> (OpGt    <$ Dhall.constructor "Gt"    Dhall.unit)
+    <> (OpGe    <$ Dhall.constructor "Ge"    Dhall.unit)
+    <> (OpEq    <$ Dhall.constructor "Eq"    Dhall.unit)
+    <> (OpMatch <$ Dhall.constructor "Match" Dhall.unit)
+    )
+
+-- | Scalar leaf carried inside compound 'AttrValue' constructors
+-- ('AVList', 'AVRecord', 'AVCompare'). Dhall lacks recursive types, so the
+-- nested element type is a separate, non-recursive union (the same trick
+-- used for 'PanInfraSpec.IR.Selector.Selector' boolean composition).
+data AttrLeaf
+  = ALText     Text
+  | ALNat      Natural
+  | ALBool     Bool
+  | ALSymbol   Text
+  | ALRegex    Text   -- ^ Ruby regex literal payload (without surrounding @/.../@).
+  | ALRubyExpr Text   -- ^ Bare Ruby expression. Emitted unquoted so the value
+                      -- can flow into a matcher that compares against a Ruby
+                      -- variable or arithmetic expression (e.g.
+                      -- @paninfraspec_total_ram_kb.to_i * 1024 * 70 \/ 100@).
+                      -- Unlike 'ALText', no escaping or surrounding quotes
+                      -- are added — the user is asserting "this is Ruby".
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall AttrLeaf where
+  autoWith _ = Dhall.union
+    (  (ALText     <$> Dhall.constructor "ALText"     Dhall.auto)
+    <> (ALNat      <$> Dhall.constructor "ALNat"      Dhall.auto)
+    <> (ALBool     <$> Dhall.constructor "ALBool"     Dhall.auto)
+    <> (ALSymbol   <$> Dhall.constructor "ALSymbol"   Dhall.auto)
+    <> (ALRegex    <$> Dhall.constructor "ALRegex"    Dhall.auto)
+    <> (ALRubyExpr <$> Dhall.constructor "ALRubyExpr" Dhall.auto)
+    )
+
+-- | Attribute value carried inside an 'Assertion'. Mirrors the Dhall union
+-- declared in @dhall/Serverspec.dhall@. The compound constructors
+-- ('AVList', 'AVRecord', 'AVCompare') carry 'AttrLeaf' instead of
+-- 'AttrValue' to stay within Dhall's non-recursive type system.
+data AttrValue
+  = AVText    Text
+  | AVNat     Natural
+  | AVBool    Bool
+  | AVSymbol  Text
+  | AVList    [AttrLeaf]
+  | AVRecord  (Map Text AttrLeaf)
+  | AVCompare CompareOp AttrLeaf
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall AttrValue where
+  autoWith _ = Dhall.union
+    (  (AVText    <$> Dhall.constructor "AVText"    Dhall.auto)
+    <> (AVNat     <$> Dhall.constructor "AVNat"     Dhall.auto)
+    <> (AVBool    <$> Dhall.constructor "AVBool"    Dhall.auto)
+    <> (AVSymbol  <$> Dhall.constructor "AVSymbol"  Dhall.auto)
+    <> (AVList    <$> Dhall.constructor "AVList"    Dhall.auto)
+    <> (AVRecord  <$> Dhall.constructor "AVRecord"  Dhall.auto)
+    <> (mkCompare <$> Dhall.constructor "AVCompare" cmpRecord)
+    )
+    where
+      mkCompare (op, v) = AVCompare op v
+      cmpRecord = Dhall.record $
+        (,) <$> Dhall.field "op"    Dhall.auto
+            <*> Dhall.field "value" Dhall.auto
+
+-- | Generic Semantic AST element. The pair @(aKind, aPrimaryKey)@ is the
+-- groupBy key the emitter uses to fold multiple state assertions for the same
+-- resource into one @describe@ block.
+--
+-- @aAttrs@ comes from Dhall as @List { mapKey, mapValue }@ via 'toMap', so
+-- duplicate keys cannot arise from the smart constructors. A user hand-writing
+-- the underlying record could produce duplicates; 'Map.fromList' is
+-- last-write-wins. Layer 3 (the emitter) catches unknown keys; silent merge of
+-- duplicate keys is acceptable for Phase 1.
+--
+-- @aModule@ is an optional product label set by @Spec.module "name" […]@ in
+-- the Dhall plan. The emitter partitions merged groups by this label so a
+-- single host can produce multiple spec files (e.g. @Web/nginx_spec.rb@ and
+-- @Web/php_spec.rb@). 'Nothing' means "no module label" — those assertions
+-- land in the layout's default file. Module-aware splitting requires a v2
+-- 'PanInfraSpec.Layout.Layout'; v1 layouts collapse all modules into one
+-- file (which is the pre-module behaviour, byte-for-byte).
+data Assertion = Assertion
+  { aKind       :: Text
+  , aPrimaryKey :: Text
+  , aAttrs      :: Map Text AttrValue
+  , aModule     :: Maybe Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall Assertion where
+  autoWith _ = Dhall.record $
+    Assertion
+      <$> Dhall.field "kind"       Dhall.auto
+      <*> Dhall.field "primaryKey" Dhall.auto
+      <*> Dhall.field "attrs"      Dhall.auto
+      <*> Dhall.field "module"     Dhall.auto
+
+-- | Binds a 'Selector' to the assertions that should apply to the matching
+-- nodes. Lives here (rather than alongside 'Selector') because 'Mapping'
+-- references 'Assertion' and 'PlanFile' references 'Mapping' — keeping them
+-- co-located avoids a circular module dependency.
+data Mapping = Mapping
+  { mSelector   :: Selector
+  , mAssertions :: [Assertion]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall Mapping where
+  autoWith _ = Dhall.record $
+    Mapping
+      <$> Dhall.field "selector"   Dhall.auto
+      <*> Dhall.field "assertions" Dhall.auto
+
+-- | The whole loaded plan file. The @targetBackend@ field is forwarded from
+-- the per-backend Dhall prelude (e.g., @Serverspec.dhall@) and lets the CLI
+-- assert that @--target@ matches the prelude the user actually imported.
+data PlanFile = PlanFile
+  { pfTargetBackend :: Text
+  , pfMappings      :: [Mapping]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall PlanFile where
+  autoWith _ = Dhall.record $
+    PlanFile
+      <$> Dhall.field "targetBackend" Dhall.auto
+      <*> Dhall.field "mappings"      Dhall.auto
+
+-- | A node and the assertions resolved for it. Internal IR only; not loaded
+-- from Dhall.
+data Job = Job
+  { jNode       :: Node
+  , jAssertions :: [Assertion]
+  }
+  deriving stock (Show, Eq, Generic)
+
+-- | The fully resolved plan handed to an emitter. @epTargetBackend@ drives
+-- emitter dispatch.
+data ExecutionPlan = ExecutionPlan
+  { epTargetBackend :: Text
+  , epJobs          :: [Job]
+  }
+  deriving stock (Show, Eq, Generic)

--- a/src/PanInfraSpec/IR/Inventory.hs
+++ b/src/PanInfraSpec/IR/Inventory.hs
@@ -1,0 +1,106 @@
+module PanInfraSpec.IR.Inventory
+  ( Role (..)
+  , CustomAttribute (..)
+  , Node (..)
+  , roleEncoder
+  , customAttributeEncoder
+  , nodeEncoder
+  ) where
+
+import Data.Functor.Contravariant (contramap, (>$<))
+import Data.Functor.Contravariant.Divisible (divided)
+import Data.String (IsString)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import qualified Dhall
+
+-- | An organisation-defined role label. Kept as a Text wrapper because
+-- vocabularies vary (Web / DBPrimary / cache / …).
+newtype Role = Role { unRole :: Text }
+  deriving stock   (Generic)
+  deriving newtype (Show, Eq, Ord, IsString, Dhall.FromDhall)
+
+-- | A per-host shell command whose stdout becomes a Ruby variable bound at
+-- the top of the generated spec file (as @paninfraspec_<caName>@). Plans can
+-- then reference that value via 'AttrLeaf.ALRubyExpr', enabling
+-- host-dependent expected values (e.g., "innodb_buffer_pool_size must be at
+-- least 70% of the host's total RAM"). Mirrors the Dhall record
+-- @{ name : Text, command : Text }@ in @dhall/Inventory.dhall@.
+data CustomAttribute = CustomAttribute
+  { caName    :: Text
+  , caCommand :: Text
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall CustomAttribute where
+  autoWith _ = Dhall.record $
+    CustomAttribute
+      <$> Dhall.field "name"    Dhall.auto
+      <*> Dhall.field "command" Dhall.auto
+
+-- | One inventory entry. Mirrors @dhall/Inventory.dhall@'s @Node@.
+data Node = Node
+  { hostname         :: Text
+  , ip               :: Maybe Text
+  , role             :: Role
+  , tags             :: [Text]
+  , customAttributes :: [CustomAttribute]
+  }
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall Node where
+  autoWith _ = Dhall.record $
+    Node
+      <$> Dhall.field "hostname"         Dhall.auto
+      <*> Dhall.field "ip"               Dhall.auto
+      <*> Dhall.field "role"             Dhall.auto
+      <*> Dhall.field "tags"             Dhall.auto
+      <*> Dhall.field "customAttributes" Dhall.auto
+
+-- | Encoder for 'Role'. Wraps Text via the Role newtype unwrap. Needed so a
+-- Dhall function value @\\(n : Inventory.Node) -> ...@ can be applied
+-- host-by-host: dhall must inject the Haskell 'Node' back into a Dhall record
+-- before evaluating the user's function. See 'PanInfraSpec.Layout'.
+roleEncoder :: Dhall.Encoder Role
+roleEncoder = contramap unRole Dhall.inject
+
+-- | Encoder for 'CustomAttribute'. Mirrors the Dhall record
+-- @{ name : Text, command : Text }@ so a user-written
+-- @\\(n : Inventory.Node) -> ...@ can reach @n.customAttributes@ during
+-- Layout evaluation if it ever wants to.
+customAttributeEncoder :: Dhall.Encoder CustomAttribute
+customAttributeEncoder = Dhall.recordEncoder $
+  splay >$< (Dhall.encodeFieldWith "name"    Dhall.inject
+       `divided`  Dhall.encodeFieldWith "command" Dhall.inject)
+  where
+    splay c = (caName c, caCommand c)
+
+-- | 'ToDhall' instance for 'CustomAttribute' lets @Dhall.inject@ derive an
+-- encoder for @[CustomAttribute]@ when building 'nodeEncoder'.
+instance Dhall.ToDhall CustomAttribute where
+  injectWith _ = customAttributeEncoder
+
+-- | 'ToDhall' instance for 'Node' lets @Dhall.inject@ derive an encoder for
+-- @[Node]@. Needed by 'PanInfraSpec.Scaffold' so a Dhall function value
+-- @\\(nodes : List Inventory.Node) -> ...@ can be applied to the resolved
+-- inventory at emit time.
+instance Dhall.ToDhall Node where
+  injectWith _ = nodeEncoder
+
+-- | Encoder for 'Node'. The field set and types must match
+-- @dhall/Inventory.dhall@'s @Node@ exactly, otherwise the user's
+-- @\\(n : Inventory.Node) -> ...@ will not type-check at evaluation time.
+--
+-- 'Dhall.RecordEncoder' is not a 'Semigroup' in dhall-1.42, so we build the
+-- record by composing field encoders through 'Divisible' ('divided') and
+-- splaying 'Node' into a right-nested tuple.
+nodeEncoder :: Dhall.Encoder Node
+nodeEncoder = Dhall.recordEncoder $
+  splay >$< (Dhall.encodeFieldWith "hostname" Dhall.inject
+       `divided` (Dhall.encodeFieldWith "ip" Dhall.inject
+       `divided` (Dhall.encodeFieldWith "role" roleEncoder
+       `divided` (Dhall.encodeFieldWith "tags" Dhall.inject
+       `divided`  Dhall.encodeFieldWith "customAttributes" Dhall.inject))))
+  where
+    splay n = (hostname n, (ip n, (role n, (tags n, customAttributes n))))

--- a/src/PanInfraSpec/IR/Selector.hs
+++ b/src/PanInfraSpec/IR/Selector.hs
@@ -1,0 +1,35 @@
+module PanInfraSpec.IR.Selector
+  ( Selector (..)
+  ) where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+import qualified Dhall
+
+import PanInfraSpec.IR.Inventory (Role)
+
+-- | Selects which nodes a 'PanInfraSpec.IR.Assertion.Mapping' applies to.
+-- AND/OR/NOT are added in Phase 3 as additive constructors used for
+-- Haskell-side composition (e.g., CLI filter chaining). They have no Dhall
+-- surface because Dhall lacks recursive types; the four base constructors
+-- below are the full set reachable from a Dhall plan.
+data Selector
+  = SelAll
+  | SelRole Role
+  | SelTag  Text
+  | SelHost Text
+  | SelAnd  [Selector]
+  | SelOr   [Selector]
+  | SelNot  Selector
+  deriving stock (Show, Eq, Generic)
+
+instance Dhall.FromDhall Selector where
+  autoWith _ = Dhall.union
+    (  (SelAll  <$  Dhall.constructor "SelAll"  Dhall.unit)
+    <> (SelRole <$> Dhall.constructor "SelRole" Dhall.auto)
+    <> (SelTag  <$> Dhall.constructor "SelTag"  Dhall.auto)
+    <> (SelHost <$> Dhall.constructor "SelHost" Dhall.auto)
+    -- AND / OR / NOT are not exposed via Dhall; Dhall lacks recursive types.
+    -- Constructed Haskell-side only.
+    )

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,6 +22,7 @@ import qualified Roundtrip.DhallEncodingTest
 import qualified SoT.TerraformTest
 import qualified Synth.HundredHostsTest
 import qualified Unit.EmitCustomAttributesTest
+import qualified Unit.IR.SplitTest
 import qualified Unit.ScaffoldTest
 import qualified Unit.LayoutTest
 import qualified Unit.ModuleSplitTest
@@ -34,6 +35,7 @@ main = defaultMain $ testGroup "paninfraspec"
   , Unit.EmitCustomAttributesTest.tests
   , Unit.ScaffoldTest.tests
   , Unit.ModuleSplitTest.tests
+  , Unit.IR.SplitTest.tests
   , Roundtrip.DhallEncodingTest.tests
   , Property.EmitTest.tests
   , Synth.HundredHostsTest.tests

--- a/test/Unit/IR/SplitTest.hs
+++ b/test/Unit/IR/SplitTest.hs
@@ -1,0 +1,60 @@
+-- | Compile-time guarantee that the @PanInfraSpec.IR@ façade re-exports the
+-- exact same types defined in the three submodules. If a submodule defined a
+-- shadow copy, these annotations would fail to type-check.
+module Unit.IR.SplitTest (tests) where
+
+import qualified Data.Map.Strict as Map
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified PanInfraSpec.IR             as IR
+import qualified PanInfraSpec.IR.Assertion   as IRA
+import qualified PanInfraSpec.IR.Inventory   as IRI
+import qualified PanInfraSpec.IR.Selector    as IRS
+
+tests :: TestTree
+tests = testGroup "IR.Split (façade re-export identity)"
+  [ testCase "Inventory types are re-exported unchanged" inventoryIdentity
+  , testCase "Selector type is re-exported unchanged"    selectorIdentity
+  , testCase "Assertion types are re-exported unchanged" assertionIdentity
+  , testCase "Mapping/PlanFile cross-module wiring"      mappingWiring
+  ]
+
+inventoryIdentity :: Assertion
+inventoryIdentity = do
+  let r = IRI.Role "Web" :: IR.Role
+      ca = IRI.CustomAttribute "x" "y" :: IR.CustomAttribute
+      n  = IRI.Node "h" Nothing r [] [ca] :: IR.Node
+  IR.unRole r          @?= "Web"
+  IR.caName     ca     @?= "x"
+  IR.caCommand  ca     @?= "y"
+  IR.hostname   n      @?= "h"
+  IR.role       n      @?= r
+
+selectorIdentity :: Assertion
+selectorIdentity = do
+  let s = IRS.SelAll :: IR.Selector
+  case s of
+    IR.SelAll -> pure ()
+    _         -> assertFailure "SelAll re-export mismatch"
+
+assertionIdentity :: Assertion
+assertionIdentity = do
+  let a = IRA.Assertion
+            { IRA.aKind       = "package"
+            , IRA.aPrimaryKey = "nginx"
+            , IRA.aAttrs      = Map.empty
+            , IRA.aModule     = Nothing
+            } :: IR.Assertion
+  IR.aKind a @?= "package"
+
+mappingWiring :: Assertion
+mappingWiring = do
+  let a  = IRA.Assertion "package" "nginx" Map.empty Nothing
+      m  = IRA.Mapping IRS.SelAll [a] :: IR.Mapping
+      pf = IRA.PlanFile "serverspec" [m] :: IR.PlanFile
+      n  = IRI.Node "h" Nothing (IRI.Role "Web") [] []
+      j  = IRA.Job n [a] :: IR.Job
+      ep = IRA.ExecutionPlan "serverspec" [j] :: IR.ExecutionPlan
+  length (IR.pfMappings pf) @?= 1
+  length (IR.epJobs ep)     @?= 1


### PR DESCRIPTION
## Summary
- Internal-only refactor: split `src/PanInfraSpec/IR.hs` into three submodules along backend-affinity lines (`IR.Inventory` fully agnostic, `IR.Selector` agnostic in shape, `IR.Assertion` carrying backend-schema-governed `aKind` vocabulary).
- `PanInfraSpec.IR` becomes a re-export façade with an unchanged export list, so every existing `import PanInfraSpec.IR` site keeps working with zero edits.
- `Mapping` is co-located with `Assertion` (rather than `Selector` as the issue originally proposed) to avoid a `Selector` ↔ `Assertion` module cycle introduced by `PlanFile -> Mapping -> Assertion`.
- New `Unit.IR.SplitTest` smoke-tests that the façade re-exports identical types from the submodules.
- Closes #37.

## Test plan
- [x] `cabal build all` passes
- [x] `cabal test` — 97 / 97 pass (existing 93 pass with no test edits + 4 new SplitTest cases)
- [x] All golden tests still pass → `paninfraspec-gen` output is byte-for-byte unchanged
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)