### PR TITLE
Replace backendAllowedKinds case with emitter registry

### DIFF
--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -56,6 +56,7 @@ library
     , PanInfraSpec.Layout
     , PanInfraSpec.Resolve
     , PanInfraSpec.Emit
+    , PanInfraSpec.Emit.Registry
     , PanInfraSpec.Emit.Serverspec
     , PanInfraSpec.DumpPlan
     , PanInfraSpec.Scaffold

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -7,11 +7,13 @@ module PanInfraSpec.Dhall
   ) where
 
 import Data.List (find)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Dhall
 
 import PanInfraSpec.IR
+import PanInfraSpec.Emit.Registry (backendRegistry)
 
 -- | Load the inventory file via Dhall and decode to @[Node]@.
 loadInventory :: FilePath -> IO [Node]
@@ -23,32 +25,17 @@ loadInventory = Dhall.inputFile Dhall.auto
 loadPlan :: FilePath -> IO PlanFile
 loadPlan = Dhall.inputFile Dhall.auto
 
--- | Backends recognised by this build. Phase 1: @serverspec@ only.
+-- | Backends recognised by this build, derived from the cross-backend
+-- 'backendRegistry'. Each emitter contributes its own entry.
 knownBackends :: [Text]
-knownBackends = ["serverspec"]
+knownBackends = Map.keys backendRegistry
 
 -- | Allowed @aKind@ values per backend. Acts as the layer-2 defence against
 -- Smart Constructor 迂回 (a user hand-writing an Assertion record bypassing
--- the Dhall smart constructors).
+-- the Dhall smart constructors). Looked up from 'backendRegistry' so each
+-- backend module owns its own allowlist.
 backendAllowedKinds :: Text -> [Text]
-backendAllowedKinds = \case
-  "serverspec" ->
-    [ "service", "package", "port", "file", "command"
-    , "user", "group", "process", "mount", "interface", "kernel-module"
-    , "bond", "bridge", "default_gateway", "host"
-    , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
-    , "selinux", "selinux_module", "linux_audit_system"
-    , "linux_kernel_parameter", "cgroup"
-    , "windows_feature", "windows_registry_key"
-    , "x509_certificate", "cron"
-    -- Phase 3: serverspec.org coverage completion
-    , "lxc", "mail_alias", "ppa", "yumrepo"
-    , "iis_app_pool", "iis_website"
-    , "mysql_config", "php_config"
-    , "x509_private_key", "zfs"
-    , "docker_container", "docker_image"
-    ]
-  _            -> []
+backendAllowedKinds name = Map.findWithDefault [] name backendRegistry
 
 -- | Layer-2 validation: structural integrity + backend kind allowlist.
 -- Layer 3 (attrs schema, conflict fail-safe) is the emitter's responsibility.

--- a/src/PanInfraSpec/Emit/Registry.hs
+++ b/src/PanInfraSpec/Emit/Registry.hs
@@ -1,0 +1,19 @@
+-- | Cross-backend registry of allowed @aKind@ values. Each emitter
+-- contributes its own entry, and the layer-2 validator in
+-- 'PanInfraSpec.Dhall' looks up the per-backend allowlist here instead of
+-- pattern-matching on backend names. Adding a new backend requires only a
+-- new module plus one entry in this map.
+module PanInfraSpec.Emit.Registry
+  ( backendRegistry
+  ) where
+
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
+
+import qualified PanInfraSpec.Emit.Serverspec as Serverspec
+
+backendRegistry :: Map Text [Text]
+backendRegistry = Map.fromList
+  [ ("serverspec", Serverspec.serverspecAllowedKinds)
+  ]

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -3,6 +3,7 @@ module PanInfraSpec.Emit.Serverspec
     -- * Schema (exported for property testing)
   , AttrTag (..)
   , serverspecSchema
+  , serverspecAllowedKinds
   ) where
 
 import Control.Monad (foldM, forM_, unless, when)
@@ -197,6 +198,12 @@ serverspecSchema = Map.fromList
   , ("docker_image", Map.fromList
       [ ("exist", ATBool) ])
   ]
+
+-- | Allowed @aKind@ values for the Serverspec backend, derived from the
+-- 'serverspecSchema' keys. This is the Serverspec emitter's contribution to
+-- the cross-backend kind registry consumed by 'PanInfraSpec.Dhall.validate'.
+serverspecAllowedKinds :: [Text]
+serverspecAllowedKinds = Map.keys serverspecSchema
 
 -- | Kinds whose @describe@ block takes no primary-key argument
 -- (e.g. @describe selinux do ... end@). The Dhall smart constructor for these


### PR DESCRIPTION
## Summary
- Each emitter now contributes its allowed-kind list to a new cross-backend registry (`PanInfraSpec.Emit.Registry`); `Dhall.validate` looks the list up there instead of pattern-matching on backend names.
- The Serverspec contribution is derived from `Map.keys serverspecSchema`, collapsing the two sources of truth that previously had to be hand-synced.
- `Dhall.knownBackends` is now `Map.keys backendRegistry`, so `--target` recognition is registry-driven too.
- No behavior change: `validate` accepts/rejects the same set of inputs and `paninfraspec-gen` output is byte-identical (golden tests pass unchanged).
- Closes #39. Pairs with #40 (Emit dispatch registry); both can land independently and the same `Emit.Registry` module can grow into a `Map Text BackendEntry` later.

## Test plan
- [x] `cabal build all` — compiles cleanly with no warnings
- [x] `cabal test paninfraspec-test` — all 97 tests pass with no test edits, including `Unit/ValidateTest` (`layer2KindAllowlist`, `layer2UnknownBackend`)
- [x] Golden tests (`flatGoldenTests`, `byRoleGoldenTests`, `ansibleSpecGoldenTests`) pass — confirms byte-identical output
- [x] `grep -n '"serverspec"' src/PanInfraSpec/Dhall.hs` returns nothing — no hardcoded backend name remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)