### PR TITLE
Replace Emit.hs case dispatch with a backend registry

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,8 +14,14 @@ fails fast rather than emit Ruby that is guaranteed to fail at run time.
 The arrow above is drawn for Serverspec, but the IR and the emitter
 interface are backend-agnostic. Adding a new backend is a new Dhall
 prelude plus a new emitter module — no changes to existing inputs, the
-IR, or other emitters. The dispatcher in
-[`src/PanInfraSpec/Emit.hs`](../src/PanInfraSpec/Emit.hs) routes on
-`--target`, and
+IR, or other emitters. The registry in
+[`src/PanInfraSpec/Emit.hs`](../src/PanInfraSpec/Emit.hs) maps
+`--target` to a `BackendEntry` (emitter + allowed-kinds list); wiring up
+a new backend is one new import and one new entry in that map.
 [`src/PanInfraSpec/Emit/Serverspec.hs`](../src/PanInfraSpec/Emit/Serverspec.hs)
-is the reference implementation. InSpec is the next backend planned.
+is the reference implementation, exporting `serverspecBackend ::
+BackendEntry`. The same registry is the canonical source for
+`knownBackends` and `backendAllowedKinds`, so layer-2 validation in
+[`src/PanInfraSpec/Dhall.hs`](../src/PanInfraSpec/Dhall.hs) and
+the dispatch in `emitFor` cannot drift apart. InSpec is the next
+backend planned.

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -56,6 +56,7 @@ library
     , PanInfraSpec.Layout
     , PanInfraSpec.Resolve
     , PanInfraSpec.Emit
+    , PanInfraSpec.Emit.Backend
     , PanInfraSpec.Emit.Serverspec
     , PanInfraSpec.DumpPlan
     , PanInfraSpec.Scaffold
@@ -85,6 +86,7 @@ test-suite paninfraspec-test
     , Unit.EmitCustomAttributesTest
     , Unit.ScaffoldTest
     , Unit.ModuleSplitTest
+    , Unit.RegistryTest
     , Unit.IR.SplitTest
     , Roundtrip.DhallEncodingTest
     , Property.EmitTest

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -11,6 +11,7 @@ import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Dhall
 
+import PanInfraSpec.Emit (backendAllowedKinds, knownBackends)
 import PanInfraSpec.IR
 
 -- | Load the inventory file via Dhall and decode to @[Node]@.
@@ -22,33 +23,6 @@ loadInventory = Dhall.inputFile Dhall.auto
 -- prelude so the CLI can compare it against @--target@.
 loadPlan :: FilePath -> IO PlanFile
 loadPlan = Dhall.inputFile Dhall.auto
-
--- | Backends recognised by this build. Phase 1: @serverspec@ only.
-knownBackends :: [Text]
-knownBackends = ["serverspec"]
-
--- | Allowed @aKind@ values per backend. Acts as the layer-2 defence against
--- Smart Constructor 迂回 (a user hand-writing an Assertion record bypassing
--- the Dhall smart constructors).
-backendAllowedKinds :: Text -> [Text]
-backendAllowedKinds = \case
-  "serverspec" ->
-    [ "service", "package", "port", "file", "command"
-    , "user", "group", "process", "mount", "interface", "kernel-module"
-    , "bond", "bridge", "default_gateway", "host"
-    , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
-    , "selinux", "selinux_module", "linux_audit_system"
-    , "linux_kernel_parameter", "cgroup"
-    , "windows_feature", "windows_registry_key"
-    , "x509_certificate", "cron"
-    -- Phase 3: serverspec.org coverage completion
-    , "lxc", "mail_alias", "ppa", "yumrepo"
-    , "iis_app_pool", "iis_website"
-    , "mysql_config", "php_config"
-    , "x509_private_key", "zfs"
-    , "docker_container", "docker_image"
-    ]
-  _            -> []
 
 -- | Layer-2 validation: structural integrity + backend kind allowlist.
 -- Layer 3 (attrs schema, conflict fail-safe) is the emitter's responsibility.

--- a/src/PanInfraSpec/Emit.hs
+++ b/src/PanInfraSpec/Emit.hs
@@ -1,23 +1,46 @@
 module PanInfraSpec.Emit
   ( emitFor
+  , knownBackends
+  , backendAllowedKinds
+  , registry
   ) where
 
 import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 
-import PanInfraSpec.Scaffold (Scaffold)
+import PanInfraSpec.Emit.Backend (BackendEntry (..))
+import qualified PanInfraSpec.Emit.Serverspec as Serverspec
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (Layout)
-import qualified PanInfraSpec.Emit.Serverspec as Serverspec
+import PanInfraSpec.Scaffold (Scaffold)
 
--- | Dispatch on 'epTargetBackend'. The chosen emitter performs its own
--- backend guard at the top of its 'emit', so a misrouted call still produces
--- an explicit error rather than silently mis-formatting.
---
--- The 'Scaffold' argument supplies the runner-specific files (Rakefile /
--- spec_helper.rb / inventory-derived auxiliaries). 'Layout' still owns
--- per-host spec-file paths.
+-- | Single source of truth for which backends this build knows about. Adding a
+-- new backend is one new import and one new entry in this map; no other
+-- dispatcher edits are required.
+registry :: Map Text BackendEntry
+registry = Map.fromList
+  [ ("serverspec", Serverspec.serverspecBackend)
+  ]
+
+-- | Backends recognised by this build, derived from 'registry'.
+knownBackends :: [Text]
+knownBackends = Map.keys registry
+
+-- | Allowed @aKind@ values per backend, derived from 'registry'. Returns @[]@
+-- for backend names not present in the registry; 'PanInfraSpec.Dhall.validate'
+-- relies on this so an unknown backend rejects every assertion at layer 2.
+backendAllowedKinds :: Text -> [Text]
+backendAllowedKinds name =
+  maybe [] beAllowedKinds (Map.lookup name registry)
+
+-- | Dispatch on 'epTargetBackend' via the registry. The 'Scaffold' argument
+-- supplies the runner-specific files (Rakefile / spec_helper.rb /
+-- inventory-derived auxiliaries); 'Layout' still owns per-host spec-file paths.
+-- Misrouted backend calls return the historical @"unknown backend: <name>"@
+-- error message so callers (and tests) can match on it.
 emitFor :: Scaffold -> Layout -> ExecutionPlan -> Either Text (Map FilePath Text)
-emitFor scaffold layout ep = case epTargetBackend ep of
-  "serverspec" -> Serverspec.emit scaffold layout ep
-  b            -> Left ("unknown backend: " <> b)
+emitFor scaffold layout ep =
+  case Map.lookup (epTargetBackend ep) registry of
+    Just entry -> beEmitter entry scaffold layout ep
+    Nothing    -> Left ("unknown backend: " <> epTargetBackend ep)

--- a/src/PanInfraSpec/Emit/Backend.hs
+++ b/src/PanInfraSpec/Emit/Backend.hs
@@ -1,0 +1,18 @@
+module PanInfraSpec.Emit.Backend
+  ( Emitter
+  , BackendEntry (..)
+  ) where
+
+import Data.Map.Strict (Map)
+import Data.Text (Text)
+
+import PanInfraSpec.IR (ExecutionPlan)
+import PanInfraSpec.Layout (Layout)
+import PanInfraSpec.Scaffold (Scaffold)
+
+type Emitter = Scaffold -> Layout -> ExecutionPlan -> Either Text (Map FilePath Text)
+
+data BackendEntry = BackendEntry
+  { beEmitter      :: Emitter
+  , beAllowedKinds :: [Text]
+  }

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -1,5 +1,6 @@
 module PanInfraSpec.Emit.Serverspec
   ( emit
+  , serverspecBackend
     -- * Schema (exported for property testing)
   , AttrTag (..)
   , serverspecSchema
@@ -23,6 +24,7 @@ import Prettyprinter (Doc, hsep, indent, pretty, punctuate, vsep, (<+>))
 import qualified Prettyprinter as PP
 import Prettyprinter.Render.Text (renderStrict)
 
+import PanInfraSpec.Emit.Backend (BackendEntry (..))
 import PanInfraSpec.Scaffold (Scaffold (..), OutputFile (..), resolveBuiltinDerivers)
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (Layout (..), Sharing (..), applySpecPath, validateLayoutPath)
@@ -1035,3 +1037,27 @@ emit scaffold layout ep
         Just _  -> Left ("scaffold file " <> p
                          <> " collides with a generated spec file or another scaffold file")
         Nothing -> Right (Map.insert validated c acc)
+
+-- | Registry entry for the Serverspec backend. The allowed-kinds list is the
+-- layer-2 allowlist consulted by 'PanInfraSpec.Dhall.validate'; it is the
+-- canonical set of @aKind@ values this emitter understands and must stay in
+-- lockstep with the keys of 'serverspecSchema'.
+serverspecBackend :: BackendEntry
+serverspecBackend = BackendEntry
+  { beEmitter      = emit
+  , beAllowedKinds =
+      [ "service", "package", "port", "file", "command"
+      , "user", "group", "process", "mount", "interface", "kernel-module"
+      , "bond", "bridge", "default_gateway", "host"
+      , "ip6tables", "ipfilter", "ipnat", "iptables", "routing_table"
+      , "selinux", "selinux_module", "linux_audit_system"
+      , "linux_kernel_parameter", "cgroup"
+      , "windows_feature", "windows_registry_key"
+      , "x509_certificate", "cron"
+      , "lxc", "mail_alias", "ppa", "yumrepo"
+      , "iis_app_pool", "iis_website"
+      , "mysql_config", "php_config"
+      , "x509_private_key", "zfs"
+      , "docker_container", "docker_image"
+      ]
+  }

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -26,6 +26,7 @@ import qualified Unit.IR.SplitTest
 import qualified Unit.ScaffoldTest
 import qualified Unit.LayoutTest
 import qualified Unit.ModuleSplitTest
+import qualified Unit.RegistryTest
 import qualified Unit.ValidateTest
 
 main :: IO ()
@@ -35,6 +36,7 @@ main = defaultMain $ testGroup "paninfraspec"
   , Unit.EmitCustomAttributesTest.tests
   , Unit.ScaffoldTest.tests
   , Unit.ModuleSplitTest.tests
+  , Unit.RegistryTest.tests
   , Unit.IR.SplitTest.tests
   , Roundtrip.DhallEncodingTest.tests
   , Property.EmitTest.tests

--- a/test/Unit/RegistryTest.hs
+++ b/test/Unit/RegistryTest.hs
@@ -1,0 +1,38 @@
+module Unit.RegistryTest (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import PanInfraSpec.Emit (backendAllowedKinds, emitFor, knownBackends)
+import PanInfraSpec.IR (ExecutionPlan (..))
+import PanInfraSpec.Layout (defaultLayout)
+import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
+
+tests :: TestTree
+tests = testGroup "backend registry"
+  [ testCase "knownBackends lists the registered backends" knownBackendsIsServerspec
+  , testCase "backendAllowedKinds lifts from the registry" allowedKindsFromRegistry
+  , testCase "backendAllowedKinds returns [] for unregistered names" allowedKindsUnknown
+  , testCase "emitFor returns 'unknown backend: <name>' for unregistered names" emitForUnknown
+  ]
+
+knownBackendsIsServerspec :: IO ()
+knownBackendsIsServerspec =
+  knownBackends @?= ["serverspec"]
+
+allowedKindsFromRegistry :: IO ()
+allowedKindsFromRegistry = do
+  let kinds = backendAllowedKinds "serverspec"
+  assertBool "service is allowed"          ("service"          `elem` kinds)
+  assertBool "package is allowed"          ("package"          `elem` kinds)
+  assertBool "docker_container is allowed" ("docker_container" `elem` kinds)
+
+allowedKindsUnknown :: IO ()
+allowedKindsUnknown =
+  backendAllowedKinds "no_such_backend" @?= []
+
+emitForUnknown :: IO ()
+emitForUnknown =
+  let ep = ExecutionPlan "ghost" []
+  in emitFor defaultServerspecScaffold defaultLayout ep
+       @?= Left "unknown backend: ghost"


### PR DESCRIPTION
## Summary
- Introduce `PanInfraSpec.Emit.Backend` (`Emitter` type + `BackendEntry` record).
- `PanInfraSpec.Emit.Serverspec` now exports `serverspecBackend :: BackendEntry`; the allowed-kinds list moved here from `Dhall.hs`.
- `PanInfraSpec.Emit` becomes a `Map Text BackendEntry` registry. `emitFor`, `knownBackends`, and `backendAllowedKinds` are all derived from that single map, so a new backend takes one import and one map entry — no dispatcher edits.
- `PanInfraSpec.Dhall` re-exports `knownBackends` / `backendAllowedKinds` from `Emit` to keep the public API stable.
- `docs/architecture.md` updated to describe the registry wiring.

Closes #40.

## Test plan
- [x] `cabal build all` succeeds.
- [x] `cabal test` — all 101 tests pass, including the new `Unit.RegistryTest` (registry membership, derived `knownBackends`, derived `backendAllowedKinds`, and `"unknown backend: <name>"` message).
- [x] Existing golden suites (`flat`, `by-role`, `ansible_spec`) pass unchanged, confirming `paninfraspec-gen` output is byte-for-byte identical.
- [x] `Unit.ValidateTest.layer3BackendMismatch` still passes without edits — the historical `"unknown backend"` error is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)