### PR TITLE
Emit Dhall source-location comments above describe blocks (#56)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,3 +33,26 @@ BackendEntry`. The same registry is the canonical source for
 [`src/PanInfraSpec/Dhall.hs`](../src/PanInfraSpec/Dhall.hs) and
 the dispatch in `emitFor` cannot drift apart. InSpec is the next
 backend planned.
+
+## Source-location threading
+
+The plan loader runs a small AST walker
+([`src/PanInfraSpec/Dhall/SourceMap.hs`](../src/PanInfraSpec/Dhall/SourceMap.hs))
+over the resolved Dhall expression, capturing the `Note Src` wrapping
+each assertion. The captured locations are spliced back into the decoded
+`Assertion` values via `aSourceLocs`, which the Serverspec emitter then
+renders as `# src:` comments above the corresponding `describe` block.
+
+`Dhall.Core.normalize` strips `Note` wrappers, so the walker cannot use
+it directly. Instead it runs a small partial normaliser
+(`betaReduceKeepNotes`) that performs β-reduction, `let` inlining,
+record-field projection, record `//` merge, and `List/fold` step-by-step
+while threading every `Note s e` through unchanged. That covers the
+smart-constructor library shipped in `dhall/Plan.dhall` and
+`dhall/Serverspec.dhall` (`Plan.make`, `Plan.onAll`, `Plan.forRole`,
+`Plan.forTag`, `Plan.forHost`, `Spec.module_`), so plan files authored
+in the natural smart-constructor style still expose per-assertion
+locations. The value side still goes through the standard
+`Dhall.normalize` + `Dhall.extract` pipeline. See
+[`docs/plan.md`](./plan.md#provenance-comments) for the user-visible
+behaviour.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,7 @@ Usage: paninfraspec-gen (--inventory PATH | --from-terraform-state PATH)
                         [--layout PATH] [--scaffold PATH]
                         [--only-role ROLE] [--only-host HOST] [--only-tag TAG]
                         [--dump-plan] [--no-source-comments]
+                        [--source-loc-in-describe]
 ```
 
 ## Flags
@@ -38,6 +39,13 @@ Usage: paninfraspec-gen (--inventory PATH | --from-terraform-state PATH)
   `describe` block. Use this for byte-stable output (e.g. when the spec
   files are diffed in CI). Comments are on by default. See
   [`plan.md`](./plan.md#provenance-comments).
+- `--source-loc-in-describe` — append the Dhall source location to each
+  `describe` block's secondary description string, so RSpec runtime output
+  (e.g. `rake spec`) prints the originating plan line next to the resource
+  name. Off by default because it changes RSpec output strings that
+  downstream CI tooling may parse. Whereas `# src:` comments only show up
+  when someone opens the generated file, this flag surfaces the location in
+  test failure logs. See [`plan.md`](./plan.md#provenance-comments).
 
 ## Exit codes
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ Usage: paninfraspec-gen (--inventory PATH | --from-terraform-state PATH)
                         --plan PATH --target BACKEND --out DIR
                         [--layout PATH] [--scaffold PATH]
                         [--only-role ROLE] [--only-host HOST] [--only-tag TAG]
-                        [--dump-plan]
+                        [--dump-plan] [--no-source-comments]
 ```
 
 ## Flags
@@ -33,6 +33,11 @@ Usage: paninfraspec-gen (--inventory PATH | --from-terraform-state PATH)
   inventory before resolution. Multiple flags are AND-composed.
 - `--dump-plan` — print the resolved plan as a tree and exit; no files are
   written. Useful for confirming which mappings hit which nodes.
+- `--no-source-comments` — suppress the `# src: <plan>:<line>:<col> — <expr>`
+  provenance comments that the emitter prepends above each generated
+  `describe` block. Use this for byte-stable output (e.g. when the spec
+  files are diffed in CI). Comments are on by default. See
+  [`plan.md`](./plan.md#provenance-comments).
 
 ## Exit codes
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -152,12 +152,33 @@ Serverspec / InSpec / Ansible vocabulary must not appear here.
   first-class constructor. Embedded inside `AttrLeaf` via `ALExpr`. Stays
   flat (non-recursive) for the same Dhall-no-recursive-types reason as
   `Selector`. Grow additively — see issue #57.
+- `IR/SourceLoc.hs` (`SourceLoc`) carries Dhall source-file coordinates
+  (file, line, col, raw text) for an IR node. `Assertion` keeps a list of
+  these in `aSourceLocs` so the Serverspec emitter can prepend
+  `# src: <file>:<line>:<col> — <expr>` comments above each `describe`
+  block. The list grows when `mergeGroup` collapses redundant assertions
+  for the same `(kind, primaryKey)` — every contributor's location is
+  preserved.
 
 ### 5.2 `PanInfraSpec.Dhall`
 
 Loaders for inventory and plan files plus layer-2 validate.
 `backendAllowedKinds` and `knownBackends` are *re-exports* of values
 derived from the `Emit` registry — no edits needed when adding a backend.
+
+`loadPlan` is split: a partial normaliser
+(`PanInfraSpec.Dhall.SourceMap.betaReduceKeepNotes`) runs on the
+resolved expression — it performs β-reduction, `let` inlining,
+field projection, record `//` merge, and `List/fold` while preserving
+every `Note s` so the AST walker (`extractAssertionLocs`) can capture
+each assertion's location. Then `Dhall.normalize` + `Dhall.extract`
+decode the value side, and `attachLocs` splices the locations back in
+by their `(mappingIdx, assertionIdx)`. Standard `Dhall.normalize` would
+discard `Note`, so we cannot use it for the location pass. The plan can
+be authored in any of the natural shapes — direct record literal,
+`Plan.make`/`Plan.onAll`/`Plan.forRole`/`Plan.forTag`/`Plan.forHost`,
+or with `Spec.module_` wrapping a list — and per-assertion locations
+will still surface.
 
 ### 5.3 `PanInfraSpec.Resolve`
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ nix run github:ikaro1192/PanInfraSpec -- \
 nix profile install github:ikaro1192/PanInfraSpec
 
 # Pin to a specific release
-nix profile install github:ikaro1192/PanInfraSpec/v0.6.0.0
+nix profile install github:ikaro1192/PanInfraSpec/v0.7.0.0
 ```
 
 Supported systems: `x86_64-linux`, `aarch64-linux`, `x86_64-darwin`,
@@ -98,14 +98,14 @@ upgrade tracking).
 
 ```sh
 docker run --rm -v "$PWD":/work \
-  ghcr.io/ikaro1192/paninfraspec-gen:0.6 \
+  ghcr.io/ikaro1192/paninfraspec-gen:0.7 \
   --inventory examples/inventory.dhall \
   --plan      examples/plan.dhall \
   --target    serverspec \
   --out       /work/out
 ```
 
-Each release publishes `latest`, the full version (`0.6.0.0`), and pin-friendly
+Each release publishes `latest`, the full version (`0.7.0.0`), and pin-friendly
 `major.minor` / `major.minor.patch` tags to
 [ghcr.io/ikaro1192/paninfraspec-gen](https://github.com/ikaro1192/PanInfraSpec/pkgs/container/paninfraspec-gen).
 Built for `linux/amd64` and `linux/arm64`. The image only generates spec

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -67,6 +67,33 @@ plans authored with `Plan.make`, `Plan.onAll`, `Plan.forRole`,
 comments transparently — there is no need to rewrite plans as raw
 record literals to get provenance trace.
 
+### Surfacing locations in `rake spec` output
+
+`# src:` comments only show up when someone opens the generated file. To
+push the same information into RSpec's *runtime* output — the failure
+summary CI logs, the lines `rake spec` prints to the terminal — pass
+`--source-loc-in-describe`. The emitter then appends the location to each
+`describe` block's secondary description string:
+
+```ruby
+describe package('nginx'), '(examples/plan.dhall:24:17)' do
+  it { should be_installed }
+end
+```
+
+`rake spec` prints:
+
+```
+Package "nginx" (examples/plan.dhall:24:17)
+  is expected to be installed
+```
+
+When several assertions merge into one `describe` block, every
+contributing location is comma-joined inside the secondary string
+(`'(plan.dhall:42:7, plan.dhall:55:9)'`). The flag is off by default
+because it changes the human-readable test output that downstream CI
+tooling may parse; opt in once your environment is ready.
+
 ## Splitting a host's spec into multiple files
 
 Tag a list of assertions with `Spec.module_ "<name>"` to label them with a

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -40,6 +40,33 @@ The four selector helpers are:
 Mappings stack: a `Web`-role node tagged `metrics` in the example above
 receives the baseline check, the full nginx stack, *and* the Prometheus port.
 
+## Provenance comments
+
+When `paninfraspec-gen` is invoked without `--no-source-comments` (the
+default), the emitter prepends a `# src:` line above every generated
+`describe` block that points back to the originating Dhall expression:
+
+```ruby
+# src: examples/plan.dhall:24:17 — Spec.package "nginx" Spec.PackageState.Installed
+describe package('nginx') do
+  it { should be_installed }
+end
+```
+
+When several assertions merge into one `describe` block (e.g. `OwnedBy` and
+`Mode` for the same file), one `# src:` line per origin is emitted so each
+contributing Dhall location is preserved. Failing Serverspec tests can then
+be traced back to the responsible Dhall expression by file, line, and
+column.
+
+The walker that captures these locations runs a small partial normaliser
+of its own (β-reduction, `let` inlining, field projection, list `//`
+record-merge, and `List/fold`) that preserves every `Note` wrapper, so
+plans authored with `Plan.make`, `Plan.onAll`, `Plan.forRole`,
+`Plan.forTag`, `Plan.forHost`, and `Spec.module_` produce `# src:`
+comments transparently — there is no need to rewrite plans as raw
+record literals to get provenance trace.
+
 ## Splitting a host's spec into multiple files
 
 Tag a list of assertions with `Spec.module_ "<name>"` to label them with a

--- a/paninfraspec.cabal
+++ b/paninfraspec.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               paninfraspec
-version:            0.6.0.0
+version:            0.7.0.0
 synopsis:           Multi-input / multi-output compiler for infra specs (Phase 1: Serverspec)
 description:        Generates Serverspec Ruby files from per-backend Dhall preludes
                     via a Generic Semantic AST.
@@ -39,10 +39,12 @@ common deps
     , aeson                >=2.0
     , contravariant
     , dhall
+    , megaparsec
     , prettyprinter
     , optparse-applicative
     , filepath
     , directory
+    , transformers
 
 library
   import:           deps
@@ -53,12 +55,15 @@ library
     , PanInfraSpec.IR.Selector
     , PanInfraSpec.IR.Assertion
     , PanInfraSpec.IR.Expr
+    , PanInfraSpec.IR.SourceLoc
     , PanInfraSpec.Dhall
+    , PanInfraSpec.Dhall.SourceMap
     , PanInfraSpec.Layout
     , PanInfraSpec.Resolve
     , PanInfraSpec.Emit
     , PanInfraSpec.Emit.Backend
     , PanInfraSpec.Emit.Serverspec
+    , PanInfraSpec.Emit.SourceMap
     , PanInfraSpec.DumpPlan
     , PanInfraSpec.Scaffold
     , PanInfraSpec.Scaffold.Defaults.Serverspec
@@ -85,10 +90,12 @@ test-suite paninfraspec-test
       Unit.ValidateTest
     , Unit.LayoutTest
     , Unit.EmitCustomAttributesTest
+    , Unit.EmitSourceMapTest
     , Unit.EmitTypedExprTest
     , Unit.ScaffoldTest
     , Unit.ModuleSplitTest
     , Unit.RegistryTest
+    , Unit.SourceLocTest
     , Unit.IR.SplitTest
     , Roundtrip.DhallEncodingTest
     , Property.EmitTest

--- a/src/PanInfraSpec/CLI.hs
+++ b/src/PanInfraSpec/CLI.hs
@@ -60,8 +60,9 @@ data Options = Options
   , optOnlyRole       :: Maybe Text
   , optOnlyHost       :: Maybe Text
   , optOnlyTag        :: Maybe Text
-  , optDumpPlan       :: Bool
-  , optSourceComments :: Bool
+  , optDumpPlan          :: Bool
+  , optSourceComments    :: Bool
+  , optSourceLocInDescribe :: Bool
   }
 
 inventorySourceP :: Parser InventorySource
@@ -131,6 +132,12 @@ parser = Options
   <*> flag True False
         ( long "no-source-comments"
        <> help "Suppress # src: provenance comments above generated describe blocks (byte-stable output)"
+        )
+  <*> switch
+        ( long "source-loc-in-describe"
+       <> help "Append the Dhall source location (file:line:col) to each describe \
+               \block's secondary description so rake spec output references the \
+               \originating plan line. Off by default; changes RSpec runtime output."
         )
 
 versionOption :: Parser (a -> a)
@@ -226,7 +233,9 @@ run opts@Options{..} = do
                              Left e -> die ("scaffold load failed: " <> e)
                              Right scaffold ->
                                let emitOpts = defaultEmitOptions
-                                                { sourceComments = optSourceComments }
+                                                { sourceComments      = optSourceComments
+                                                , sourceLocInDescribe = optSourceLocInDescribe
+                                                }
                                in case emitFor scaffold layout ep emitOpts of
                                  Left e     -> die ("emit failed: " <> e)
                                  Right outs -> writeAll optOut outs

--- a/src/PanInfraSpec/CLI.hs
+++ b/src/PanInfraSpec/CLI.hs
@@ -28,6 +28,7 @@ import qualified Paths_paninfraspec as Paths
 import PanInfraSpec.Dhall (loadInventory, loadPlan, validate)
 import PanInfraSpec.DumpPlan (dumpPlan)
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (EmitOptions (..), defaultEmitOptions)
 import PanInfraSpec.Scaffold (Scaffold, loadScaffold)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR
@@ -50,16 +51,17 @@ data InventorySource
   | FromTerraformState FilePath
 
 data Options = Options
-  { optInventory :: InventorySource
-  , optPlan      :: FilePath
-  , optTarget    :: Text
-  , optOut       :: FilePath
-  , optLayout    :: Maybe FilePath
-  , optScaffold  :: Maybe FilePath
-  , optOnlyRole  :: Maybe Text
-  , optOnlyHost  :: Maybe Text
-  , optOnlyTag   :: Maybe Text
-  , optDumpPlan  :: Bool
+  { optInventory      :: InventorySource
+  , optPlan           :: FilePath
+  , optTarget         :: Text
+  , optOut            :: FilePath
+  , optLayout         :: Maybe FilePath
+  , optScaffold       :: Maybe FilePath
+  , optOnlyRole       :: Maybe Text
+  , optOnlyHost       :: Maybe Text
+  , optOnlyTag        :: Maybe Text
+  , optDumpPlan       :: Bool
+  , optSourceComments :: Bool
   }
 
 inventorySourceP :: Parser InventorySource
@@ -125,6 +127,10 @@ parser = Options
   <*> switch
         ( long "dump-plan"
        <> help "Print the resolved ExecutionPlan as a tree and exit (no output written)"
+        )
+  <*> flag True False
+        ( long "no-source-comments"
+       <> help "Suppress # src: provenance comments above generated describe blocks (byte-stable output)"
         )
 
 versionOption :: Parser (a -> a)
@@ -218,9 +224,12 @@ run opts@Options{..} = do
                            scaffoldRes <- resolveScaffold optScaffold
                            case scaffoldRes of
                              Left e -> die ("scaffold load failed: " <> e)
-                             Right scaffold -> case emitFor scaffold layout ep of
-                               Left e     -> die ("emit failed: " <> e)
-                               Right outs -> writeAll optOut outs
+                             Right scaffold ->
+                               let emitOpts = defaultEmitOptions
+                                                { sourceComments = optSourceComments }
+                               in case emitFor scaffold layout ep emitOpts of
+                                 Left e     -> die ("emit failed: " <> e)
+                                 Right outs -> writeAll optOut outs
 
 -- | Layer-1 check: the @--target@ flag must match the @targetBackend@ field
 -- the plan file forwards from its imported per-backend Dhall prelude.

--- a/src/PanInfraSpec/Dhall.hs
+++ b/src/PanInfraSpec/Dhall.hs
@@ -6,11 +6,21 @@ module PanInfraSpec.Dhall
   , knownBackends
   ) where
 
+import Control.Exception (throwIO)
+import qualified Control.Monad.Trans.State.Strict as State
 import Data.List (find)
 import Data.Text (Text)
 import qualified Data.Text as T
+import qualified Data.Text.IO as TIO
 import qualified Dhall
+import qualified Dhall.Core as DC
+import qualified Dhall.Import as DImport
+import qualified Dhall.Marshal.Decode as DDecode
+import qualified Dhall.TypeCheck as DTypeCheck
+import qualified Dhall.Parser as DParser
+import System.FilePath (takeDirectory)
 
+import PanInfraSpec.Dhall.SourceMap (attachLocs, extractAssertionLocs)
 import PanInfraSpec.Emit (backendAllowedKinds, knownBackends)
 import PanInfraSpec.IR
 
@@ -18,11 +28,38 @@ import PanInfraSpec.IR
 loadInventory :: FilePath -> IO [Node]
 loadInventory = Dhall.inputFile Dhall.auto
 
--- | Load the plan file via Dhall and decode to a 'PlanFile' record. The
--- record carries @targetBackend@ forwarded from the imported per-backend
--- prelude so the CLI can compare it against @--target@.
+-- | Load the plan file and decode to a 'PlanFile'. We bypass
+-- 'Dhall.inputFile' so we can run an AST walker over the resolved-but-still
+-- annotated tree, capturing each assertion's 'SourceLoc' before
+-- normalisation strips the @Note s@ wrappers. The decoded value goes through
+-- 'Dhall.input' as before; 'attachLocs' splices the captured locations back
+-- in by their declaration index.
+--
+-- The walker only finds locations when the plan's outermost expression is a
+-- record literal containing a @mappings@ list — i.e. the plan is written as
+-- @{ targetBackend = ..., mappings = [...] }@ rather than going through
+-- @Plan.make@'s lambda (which would be β-reduced and thus lose all
+-- 'Note' wrappers). Plans authored against the older smart-constructor
+-- shape still load; they simply produce no @# src:@ comments because no
+-- locations were captured.
 loadPlan :: FilePath -> IO PlanFile
-loadPlan = Dhall.inputFile Dhall.auto
+loadPlan path = do
+  raw      <- TIO.readFile path
+  parsed   <- case DParser.exprFromText path raw of
+    Left  e -> throwIO e
+    Right e -> pure e
+  resolved <- State.evalStateT
+                (DImport.loadWith parsed)
+                (DImport.emptyStatus (takeDirectory path))
+  case DTypeCheck.typeOf resolved of
+    Left  e -> throwIO e
+    Right _ -> pure ()
+  let locs       = extractAssertionLocs path resolved
+      normalized = DC.normalize resolved
+  pf <- case DDecode.toMonadic (Dhall.extract Dhall.auto normalized) of
+    Right a   -> pure a
+    Left errs -> throwIO errs
+  pure (attachLocs locs pf)
 
 -- | Layer-2 validation: structural integrity + backend kind allowlist.
 -- Layer 3 (attrs schema, conflict fail-safe) is the emitter's responsibility.

--- a/src/PanInfraSpec/Dhall/SourceMap.hs
+++ b/src/PanInfraSpec/Dhall/SourceMap.hs
@@ -1,0 +1,217 @@
+module PanInfraSpec.Dhall.SourceMap
+  ( extractAssertionLocs
+  , attachLocs
+  , betaReduceKeepNotes
+  ) where
+
+import qualified Data.Foldable as F
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (maybeToList)
+import Data.Void (Void)
+
+import qualified Dhall.Core as DC
+import qualified Dhall.Map  as DMap
+import Dhall.Src (Src (..))
+import qualified Text.Megaparsec.Pos as Pos
+
+import PanInfraSpec.IR
+  ( Assertion (..)
+  , Mapping (..)
+  , PlanFile (..)
+  )
+import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
+
+-- | Walk the resolved Plan AST and produce, for every assertion a Plan can
+-- contain, the 'SourceLoc' that wraps it in the original Dhall file.
+--
+-- The walker indexes each assertion by @(mappingIdx, assertionIdx)@ in
+-- declaration order; 'attachLocs' uses the same index pair to splice the
+-- locations back into the corresponding 'Assertion' values after Dhall has
+-- finished decoding the value side.
+--
+-- This must run before normalisation. 'Dhall.Core.normalize' rewrites
+-- @Note s e@ to @e@, and that throws away everything we need. The plan
+-- pipeline therefore typechecks the resolved AST, runs this walker, and only
+-- then hands a normalised copy to 'Dhall.input' for value extraction.
+extractAssertionLocs
+  :: FilePath
+  -> DC.Expr Src Void
+  -> Map (Int, Int) SourceLoc
+extractAssertionLocs path expr = case stripWrappers (betaReduceKeepNotes expr) of
+  DC.RecordLit fields ->
+    maybe Map.empty (walkMappings . DC.recordFieldValue) (DMap.lookup "mappings" fields)
+  _ -> Map.empty
+  where
+    walkMappings e = case stripWrappers e of
+      DC.ListLit _ items ->
+        Map.unions
+          [ walkMapping mIdx item
+          | (mIdx, item) <- zip [0 ..] (F.toList items)
+          ]
+      _ -> Map.empty
+
+    walkMapping mIdx e = case stripWrappers e of
+      DC.RecordLit fields ->
+        maybe
+          Map.empty
+          (walkAssertions mIdx . DC.recordFieldValue)
+          (DMap.lookup "assertions" fields)
+      _ -> Map.empty
+
+    walkAssertions mIdx e = case stripWrappers e of
+      DC.ListLit _ items ->
+        Map.fromList
+          [ ((mIdx, aIdx), srcToLoc path src)
+          | (aIdx, item) <- zip [0 ..] (F.toList items)
+          , src           <- maybeToList (outermostSrc item)
+          ]
+      _ -> Map.empty
+
+-- | Peel away purely structural wrappers — 'Note' annotations introduced by
+-- the parser, 'Let' bindings introduced by @let X = ... in ...@, and type
+-- 'Annot' annotations — to find the underlying record/list literal a writer
+-- intends. We resolve imports before reaching this walker, so any @let@ that
+-- bound an import (e.g. @let Spec = ./Serverspec.dhall@) is just a let
+-- holding a record literal whose body still references @Spec@; descending
+-- into the @in ...@ side and ignoring the binder is what we want, since the
+-- mapping/assertion structure we care about lives in the body.
+stripWrappers :: DC.Expr Src a -> DC.Expr Src a
+stripWrappers (DC.Note _ e)  = stripWrappers e
+stripWrappers (DC.Let _ e)   = stripWrappers e
+stripWrappers (DC.Annot e _) = stripWrappers e
+stripWrappers e              = e
+
+-- | The outermost 'Src' that wraps an expression, if any. Dhall sometimes
+-- produces nested 'Note' constructors; we want the widest range so the
+-- emitted comment shows the entire @file_owner "/x" "y"@ application rather
+-- than just the head identifier.
+outermostSrc :: DC.Expr Src a -> Maybe Src
+outermostSrc (DC.Note s _) = Just s
+outermostSrc _             = Nothing
+
+srcToLoc :: FilePath -> Src -> SourceLoc
+srcToLoc path src = SourceLoc
+  { slFile      = path
+  , slStartLine = Pos.unPos (Pos.sourceLine   (srcStart src))
+  , slStartCol  = Pos.unPos (Pos.sourceColumn (srcStart src))
+  , slEndLine   = Pos.unPos (Pos.sourceLine   (srcEnd   src))
+  , slEndCol    = Pos.unPos (Pos.sourceColumn (srcEnd   src))
+  , slText      = srcText src
+  }
+
+-- | Partial normaliser that performs β-reduction, let-inlining, and
+-- record-field projection while leaving every 'DC.Note' wrapper in place.
+--
+-- 'Dhall.Core.normalize' would do all of the same reductions and more, but
+-- it discards 'Note' annotations along the way — and those are exactly what
+-- the source-map walker needs. By driving the reductions ourselves we can
+-- preserve every 'Note' that ends up surviving in the head-normal form, so
+-- a plan that goes through smart constructors like 'Plan.forRole' still
+-- exposes each assertion's location to the walker.
+--
+-- This intentionally implements only the subset Dhall needs to evaluate the
+-- @Plan.dhall@ / @Serverspec.dhall@ smart-constructor library: lambda
+-- application, top-level @let@ inlining, and field projection on record
+-- literals. Other reductions (booleans, list folds, type-level rewrites,
+-- @merge@, …) are left as-is — they do not appear in plan files in
+-- practice, and supporting them would risk drifting out of sync with
+-- dhall's own normaliser.
+betaReduceKeepNotes :: DC.Expr Src a -> DC.Expr Src a
+betaReduceKeepNotes = go
+  where
+    go expr = case expr of
+      DC.Note s e -> DC.Note s (go e)
+
+      DC.App f x ->
+        let f' = go f
+            x' = go x
+            spineHead = collectAppHead f'
+            spineArgs = collectAppArgs f' ++ [x']
+        in case peelOuter spineHead of
+             DC.Lam _ binding body ->
+               let var = DC.V (DC.functionBindingVariable binding) 0
+               in go (DC.subst var x' body)
+             DC.ListFold
+               | [_typeA, listExpr, _typeB, fn, z] <- spineArgs
+               , DC.ListLit _ items <- peelOuter (go listExpr) ->
+                   go (foldr (\elt acc -> DC.App (DC.App fn elt) acc) z (F.toList items))
+             _ -> DC.App f' x'
+
+      DC.Let binding body ->
+        let var = DC.V (DC.variable binding) 0
+            val = go (DC.value binding)
+        in go (DC.subst var val body)
+
+      DC.Field e fs ->
+        let e' = go e
+        in case peelOuter e' of
+             DC.RecordLit m
+               | Just rf <- DMap.lookup (DC.fieldSelectionLabel fs) m ->
+                   go (DC.recordFieldValue rf)
+             _ -> DC.Field e' fs
+
+      DC.RecordLit m ->
+        DC.RecordLit (fmap (\rf -> rf { DC.recordFieldValue = go (DC.recordFieldValue rf) }) m)
+
+      DC.ListLit ann es ->
+        DC.ListLit (fmap go ann) (fmap go es)
+
+      DC.ListAppend l r ->
+        case (peelOuter (go l), peelOuter (go r)) of
+          (DC.ListLit ann ls, DC.ListLit _ rs) -> DC.ListLit ann (ls <> rs)
+          (l', r')                             -> DC.ListAppend l' r'
+
+      DC.Prefer cs pref l r ->
+        let l' = go l
+            r' = go r
+        in case (peelOuter l', peelOuter r') of
+             (DC.RecordLit ml, DC.RecordLit mr) ->
+               -- Reattach the left-hand outer Note so an assertion built as
+               -- @<assertion> // { module = Some "x" }@ keeps the
+               -- assertion's original source location after Spec.module_
+               -- has been β-reduced.
+               carryOuterNote l' (DC.RecordLit (DMap.union mr ml))
+             _ -> DC.Prefer cs pref l' r'
+
+      DC.Annot e _ -> go e
+
+      _ -> expr
+
+    peelOuter (DC.Note _ e) = peelOuter e
+    peelOuter e             = e
+
+    -- Wrap @new@ with the outermost 'Note' that appears on @orig@, so
+    -- structural reductions (record merge, list-fold step) do not strip
+    -- the source location attached to the operand.
+    carryOuterNote (DC.Note s _) new = DC.Note s new
+    carryOuterNote _             new = new
+
+    -- Collect the head of an application spine (App f x → … → App (App f x1) x2)
+    -- so multi-argument builtins like @List/fold@ can be matched once their
+    -- whole argument list is in hand.
+    collectAppHead (DC.App f _) = collectAppHead f
+    collectAppHead (DC.Note _ e) = collectAppHead e
+    collectAppHead e             = e
+
+    collectAppArgs = reverse . spine
+      where
+        spine (DC.App f x)  = x : spine f
+        spine (DC.Note _ e) = spine e
+        spine _             = []
+
+-- | Splice the locations produced by 'extractAssertionLocs' back into the
+-- decoded 'PlanFile'. The two share an indexing convention
+-- @(mappingIdx, assertionIdx)@ so order-preserving Dhall decoders keep the
+-- correspondence intact.
+attachLocs :: Map (Int, Int) SourceLoc -> PlanFile -> PlanFile
+attachLocs locs pf = pf
+  { pfMappings =
+      [ m { mAssertions =
+              [ a { aSourceLocs = maybeToList (Map.lookup (mIdx, aIdx) locs) }
+              | (aIdx, a) <- zip [0 ..] (mAssertions m)
+              ]
+          }
+      | (mIdx, m) <- zip [0 ..] (pfMappings pf)
+      ]
+  }

--- a/src/PanInfraSpec/DumpPlan.hs
+++ b/src/PanInfraSpec/DumpPlan.hs
@@ -42,7 +42,7 @@ renderIp = \case
   Just a   -> "  ip=" <> a
 
 renderGroup :: Assertion -> Text
-renderGroup (Assertion k pk attrs _) =
+renderGroup (Assertion k pk attrs _ _) =
   "│   ├── " <> k <> " " <> quoted pk <> " " <> renderAttrs attrs
 
 renderAttrs :: Map.Map Text AttrValue -> Text

--- a/src/PanInfraSpec/Emit.hs
+++ b/src/PanInfraSpec/Emit.hs
@@ -10,6 +10,7 @@ import qualified Data.Map.Strict as Map
 import Data.Text (Text)
 
 import PanInfraSpec.Emit.Backend (BackendEntry (..))
+import PanInfraSpec.Emit.SourceMap (EmitOptions)
 import qualified PanInfraSpec.Emit.Serverspec as Serverspec
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (Layout)
@@ -39,8 +40,13 @@ backendAllowedKinds name =
 -- inventory-derived auxiliaries); 'Layout' still owns per-host spec-file paths.
 -- Misrouted backend calls return the historical @"unknown backend: <name>"@
 -- error message so callers (and tests) can match on it.
-emitFor :: Scaffold -> Layout -> ExecutionPlan -> Either Text (Map FilePath Text)
-emitFor scaffold layout ep =
+emitFor
+  :: Scaffold
+  -> Layout
+  -> ExecutionPlan
+  -> EmitOptions
+  -> Either Text (Map FilePath Text)
+emitFor scaffold layout ep opts =
   case Map.lookup (epTargetBackend ep) registry of
-    Just entry -> beEmitter entry scaffold layout ep
+    Just entry -> beEmitter entry scaffold layout ep opts
     Nothing    -> Left ("unknown backend: " <> epTargetBackend ep)

--- a/src/PanInfraSpec/Emit/Backend.hs
+++ b/src/PanInfraSpec/Emit/Backend.hs
@@ -6,11 +6,17 @@ module PanInfraSpec.Emit.Backend
 import Data.Map.Strict (Map)
 import Data.Text (Text)
 
+import PanInfraSpec.Emit.SourceMap (EmitOptions)
 import PanInfraSpec.IR (ExecutionPlan)
 import PanInfraSpec.Layout (Layout)
 import PanInfraSpec.Scaffold (Scaffold)
 
-type Emitter = Scaffold -> Layout -> ExecutionPlan -> Either Text (Map FilePath Text)
+type Emitter
+  = Scaffold
+  -> Layout
+  -> ExecutionPlan
+  -> EmitOptions
+  -> Either Text (Map FilePath Text)
 
 data BackendEntry = BackendEntry
   { beEmitter      :: Emitter

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -26,7 +26,11 @@ import qualified Prettyprinter as PP
 import Prettyprinter.Render.Text (renderStrict)
 
 import PanInfraSpec.Emit.Backend (BackendEntry (..))
-import PanInfraSpec.Emit.SourceMap (EmitOptions (..), formatSrcComment)
+import PanInfraSpec.Emit.SourceMap
+  ( EmitOptions (..)
+  , formatDescribeSrcLoc
+  , formatSrcComment
+  )
 import PanInfraSpec.Scaffold (Scaffold (..), OutputFile (..), resolveBuiltinDerivers)
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (Layout (..), Sharing (..), applySpecPath, validateLayoutPath)
@@ -922,8 +926,10 @@ lookupText k m = case Map.lookup k m of
 -- @phpConfigWithIni@).
 --
 -- 'EmitOptions' controls whether @# src:@ provenance comments are prepended
--- above the @describe@ header (one line per 'aSourceLocs' entry). The header
--- itself is unchanged, so disabling comments keeps byte-stable output.
+-- above the @describe@ header (one line per 'aSourceLocs' entry) and whether
+-- the Dhall source location is woven into the @describe@ block's secondary
+-- description string (so RSpec runtime output references the originating plan
+-- line). Disabling both keeps byte-stable output.
 formatGroup :: EmitOptions -> Assertion -> Either Text (Doc ann)
 formatGroup opts (Assertion k pk attrs0 _ locs) = do
   let resource = pretty (kindToRubyResource k)
@@ -933,16 +939,25 @@ formatGroup opts (Assertion k pk attrs0 _ locs) = do
         = (Just p, Map.delete "_ini" attrs0)
         | otherwise
         = (Nothing, attrs0)
-  header <-
+  subject <-
     if Set.member k singletonKinds
-      then Right ("describe" <+> resource <+> "do")
+      then Right resource
       else do
         hd <- primaryDoc k pk
         let args = case iniArg of
               Nothing -> hd
               Just p  -> hd <> "," <+> ":ini" <+> "=>" <+> rubyString p
-        Right ("describe" <+> resource <> "(" <> args <> ")" <+> "do")
-  let body         = vsep (renderAttrs k attrs)
+        Right (resource <> "(" <> args <> ")")
+  let locSecondary
+        | sourceLocInDescribe opts
+        , Just s <- formatDescribeSrcLoc locs
+            = Just (rubyString s)
+        | otherwise
+            = Nothing
+      header = case locSecondary of
+        Nothing -> "describe" <+> subject <+> "do"
+        Just s  -> "describe" <+> subject <> "," <+> s <+> "do"
+      body         = vsep (renderAttrs k attrs)
       commentLines = if sourceComments opts
                        then map pretty (formatSrcComment locs)
                        else []

--- a/src/PanInfraSpec/Emit/Serverspec.hs
+++ b/src/PanInfraSpec/Emit/Serverspec.hs
@@ -26,6 +26,7 @@ import qualified Prettyprinter as PP
 import Prettyprinter.Render.Text (renderStrict)
 
 import PanInfraSpec.Emit.Backend (BackendEntry (..))
+import PanInfraSpec.Emit.SourceMap (EmitOptions (..), formatSrcComment)
 import PanInfraSpec.Scaffold (Scaffold (..), OutputFile (..), resolveBuiltinDerivers)
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (Layout (..), Sharing (..), applySpecPath, validateLayoutPath)
@@ -275,7 +276,7 @@ showVal = \case
 -- schema for that kind, every attr value's tag matches the expected tag, and
 -- per-kind primaryKey shape (port must be parseable as Natural).
 validateAssertion :: Assertion -> Either Text Assertion
-validateAssertion a@(Assertion k pk attrs _) = do
+validateAssertion a@(Assertion k pk attrs _ _) = do
   kindSchema <- case Map.lookup k serverspecSchema of
     Just s  -> Right s
     Nothing -> Left ("unknown kind for serverspec: " <> k)
@@ -332,7 +333,11 @@ mergeGroup (a :| rest) = foldM step a rest
     step acc nxt = do
       mergedAttrs  <- mergeAttrs  (aKind acc) (aPrimaryKey acc) (aAttrs  acc) (aAttrs  nxt)
       mergedModule <- mergeModule (aKind acc) (aPrimaryKey acc) (aModule acc) (aModule nxt)
-      pure acc { aAttrs = mergedAttrs, aModule = mergedModule }
+      pure acc
+        { aAttrs      = mergedAttrs
+        , aModule     = mergedModule
+        , aSourceLocs = aSourceLocs acc <> aSourceLocs nxt
+        }
 
 -- | Reject two assertions for the same @(kind, primaryKey)@ that disagree on
 -- their module label. The user has to either align the labels, drop them,
@@ -915,8 +920,12 @@ lookupText k m = case Map.lookup k m of
 -- The @php_config@ kind injects an @:ini => '<path>'@ keyword arg into the
 -- header when the @_ini@ sentinel attribute is present (see Dhall
 -- @phpConfigWithIni@).
-formatGroup :: Assertion -> Either Text (Doc ann)
-formatGroup (Assertion k pk attrs0 _) = do
+--
+-- 'EmitOptions' controls whether @# src:@ provenance comments are prepended
+-- above the @describe@ header (one line per 'aSourceLocs' entry). The header
+-- itself is unchanged, so disabling comments keeps byte-stable output.
+formatGroup :: EmitOptions -> Assertion -> Either Text (Doc ann)
+formatGroup opts (Assertion k pk attrs0 _ locs) = do
   let resource = pretty (kindToRubyResource k)
       (iniArg, attrs)
         | k == "php_config"
@@ -933,8 +942,11 @@ formatGroup (Assertion k pk attrs0 _) = do
               Nothing -> hd
               Just p  -> hd <> "," <+> ":ini" <+> "=>" <+> rubyString p
         Right ("describe" <+> resource <> "(" <> args <> ")" <+> "do")
-  let body = vsep (renderAttrs k attrs)
-  pure $ vsep [header, indent 2 body, "end"]
+  let body         = vsep (renderAttrs k attrs)
+      commentLines = if sourceComments opts
+                       then map pretty (formatSrcComment locs)
+                       else []
+  pure $ vsep (commentLines ++ [header, indent 2 body, "end"])
 
 -- | Validate the @customAttributes@ list of a 'Node' before emitting any
 -- @paninfraspec_<name> = ...@ preamble lines. Rejects:
@@ -996,8 +1008,8 @@ renderCustomAttributePreamble cas = vsep
 -- Doing the merge BEFORE the partition is what preserves the
 -- "exit-status=0 vs exit-status=1 for the same command" safety net even
 -- when the conflicting commands sit in different module wrappers.
-formatJob :: Layout -> Job -> Either Text [(FilePath, Text)]
-formatJob layout (Job node assertions) = do
+formatJob :: EmitOptions -> Layout -> Job -> Either Text [(FilePath, Text)]
+formatJob opts layout (Job node assertions) = do
   validatedCAs <- validateCustomAttributes (customAttributes node)
   validated    <- traverse validateAssertion assertions
   merged       <- traverse mergeGroup (groupAssertions validated)
@@ -1011,7 +1023,7 @@ formatJob layout (Job node assertions) = do
     addToBucket a = Map.insertWith (++) (aModule a) [a]
 
     renderBucket cas (maybeMod, asserts) = do
-      blocks   <- traverse formatGroup asserts
+      blocks   <- traverse (formatGroup opts) asserts
       filename <- validateLayoutPath
                     (T.unpack (applySpecPath layout node maybeMod))
       let docText d = renderStrict (PP.layoutPretty PP.defaultLayoutOptions d)
@@ -1034,12 +1046,17 @@ formatJob layout (Job node assertions) = do
 -- ansible_spec's @hosts@ is a candidate — should be invoked through
 -- inventory pathways once that channel exists. For Phase 1 the per-job
 -- node list is sufficient for both shipped scaffolds.
-emit :: Scaffold -> Layout -> ExecutionPlan -> Either Text (Map FilePath Text)
-emit scaffold layout ep
+emit
+  :: Scaffold
+  -> Layout
+  -> ExecutionPlan
+  -> EmitOptions
+  -> Either Text (Map FilePath Text)
+emit scaffold layout ep opts
   | epTargetBackend ep /= "serverspec" =
       Left ("backend mismatch: expected serverspec, got " <> epTargetBackend ep)
   | otherwise = do
-      perJob  <- traverse (formatJob layout) (epJobs ep)
+      perJob  <- traverse (formatJob opts layout) (epJobs ep)
       perHost <- foldM (insertSpec (lSharing layout)) Map.empty (concat perJob)
       let nodes  = jNode <$> epJobs ep
           extras = sStaticFiles scaffold

--- a/src/PanInfraSpec/Emit/SourceMap.hs
+++ b/src/PanInfraSpec/Emit/SourceMap.hs
@@ -2,6 +2,7 @@ module PanInfraSpec.Emit.SourceMap
   ( EmitOptions (..)
   , defaultEmitOptions
   , formatSrcComment
+  , formatDescribeSrcLoc
   ) where
 
 import Data.Text (Text)
@@ -14,15 +15,27 @@ import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
 -- 'sourceComments' controls whether @# src: <file>:<line>:<col> — <expr>@
 -- provenance comments are prepended above each generated block. Disabled by
 -- @--no-source-comments@ for users who want byte-stable output.
-newtype EmitOptions = EmitOptions
-  { sourceComments :: Bool
+--
+-- 'sourceLocInDescribe' controls whether the Dhall source location is also
+-- woven into each @describe@ block's secondary description string, so RSpec
+-- runtime output (e.g. @rake spec@) prints the originating plan line next to
+-- the resource name. Off by default because it changes the human-readable
+-- test output that downstream CI tooling may parse; users opt in with
+-- @--source-loc-in-describe@.
+data EmitOptions = EmitOptions
+  { sourceComments      :: Bool
+  , sourceLocInDescribe :: Bool
   }
   deriving stock (Show, Eq)
 
--- | Default: provenance comments on. Matches the CLI default so generated
--- specs are self-documenting out of the box.
+-- | Default: provenance comments on, runtime describe-string off. The first
+-- matches the CLI default so generated specs are self-documenting out of the
+-- box; the second stays opt-in to avoid silently changing @rake spec@ output.
 defaultEmitOptions :: EmitOptions
-defaultEmitOptions = EmitOptions { sourceComments = True }
+defaultEmitOptions = EmitOptions
+  { sourceComments      = True
+  , sourceLocInDescribe = False
+  }
 
 -- | Render one @# src:@ line per 'SourceLoc'. Empty input yields no lines so
 -- callers can splice the result unconditionally with 'vsep'.
@@ -52,3 +65,24 @@ formatSrcComment = map renderOne
 
     maxOneLineLen :: Int
     maxOneLineLen = 80
+
+-- | Render a single secondary-description string suitable for RSpec's
+-- @describe <subject>, '<string>' do@ form. Returns 'Nothing' when there are
+-- no source locations so callers can omit the secondary argument entirely
+-- (the produced string is never empty otherwise).
+--
+-- Each location collapses to @file:line:col@ — the raw expression text is
+-- intentionally dropped. RSpec prints the secondary string inline with the
+-- resource name on the same line, so verbosity matters more than for the
+-- multi-line @# src:@ comment form.
+formatDescribeSrcLoc :: [SourceLoc] -> Maybe Text
+formatDescribeSrcLoc [] = Nothing
+formatDescribeSrcLoc locs =
+  Just ("(" <> T.intercalate ", " (map renderOne locs) <> ")")
+  where
+    renderOne loc =
+      T.pack (slFile loc)
+        <> ":"
+        <> T.pack (show (slStartLine loc))
+        <> ":"
+        <> T.pack (show (slStartCol loc))

--- a/src/PanInfraSpec/Emit/SourceMap.hs
+++ b/src/PanInfraSpec/Emit/SourceMap.hs
@@ -1,0 +1,54 @@
+module PanInfraSpec.Emit.SourceMap
+  ( EmitOptions (..)
+  , defaultEmitOptions
+  , formatSrcComment
+  ) where
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
+
+-- | Knobs threaded from the CLI down to each backend emitter.
+--
+-- 'sourceComments' controls whether @# src: <file>:<line>:<col> — <expr>@
+-- provenance comments are prepended above each generated block. Disabled by
+-- @--no-source-comments@ for users who want byte-stable output.
+newtype EmitOptions = EmitOptions
+  { sourceComments :: Bool
+  }
+  deriving stock (Show, Eq)
+
+-- | Default: provenance comments on. Matches the CLI default so generated
+-- specs are self-documenting out of the box.
+defaultEmitOptions :: EmitOptions
+defaultEmitOptions = EmitOptions { sourceComments = True }
+
+-- | Render one @# src:@ line per 'SourceLoc'. Empty input yields no lines so
+-- callers can splice the result unconditionally with 'vsep'.
+--
+-- Each Dhall expression is collapsed to a single line (multi-line expressions
+-- are joined with single spaces) and truncated past 'maxOneLineLen' so a
+-- pathologically long expression cannot blow up the generated file. Truncation
+-- appends a U+2026 ellipsis so readers can tell the comment was clipped.
+formatSrcComment :: [SourceLoc] -> [Text]
+formatSrcComment = map renderOne
+  where
+    renderOne loc =
+      "# src: "
+        <> T.pack (slFile loc)
+        <> ":"
+        <> T.pack (show (slStartLine loc))
+        <> ":"
+        <> T.pack (show (slStartCol loc))
+        <> " — "
+        <> oneLine (slText loc)
+
+    oneLine t =
+      let collapsed = T.unwords (T.words t)
+      in if T.length collapsed > maxOneLineLen
+           then T.take (maxOneLineLen - 1) collapsed <> "…"
+           else collapsed
+
+    maxOneLineLen :: Int
+    maxOneLineLen = 80

--- a/src/PanInfraSpec/IR.hs
+++ b/src/PanInfraSpec/IR.hs
@@ -19,11 +19,13 @@ module PanInfraSpec.IR
   , Expr (..)
   , Operand (..)
   , Assertion (..)
+  , mkAssertion
   , Selector (..)
   , Mapping (..)
   , PlanFile (..)
   , Job (..)
   , ExecutionPlan (..)
+  , SourceLoc (..)
   , roleEncoder
   , customAttributeEncoder
   , nodeEncoder
@@ -39,11 +41,13 @@ import PanInfraSpec.IR.Inventory
   )
 import PanInfraSpec.IR.Selector  (Selector (..))
 import PanInfraSpec.IR.Expr      (Expr (..), Operand (..))
+import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
 import PanInfraSpec.IR.Assertion
   ( CompareOp (..)
   , AttrLeaf (..)
   , AttrValue (..)
   , Assertion (..)
+  , mkAssertion
   , Mapping (..)
   , PlanFile (..)
   , Job (..)

--- a/src/PanInfraSpec/IR/Assertion.hs
+++ b/src/PanInfraSpec/IR/Assertion.hs
@@ -3,6 +3,7 @@ module PanInfraSpec.IR.Assertion
   , AttrLeaf (..)
   , AttrValue (..)
   , Assertion (..)
+  , mkAssertion
   , Mapping (..)
   , PlanFile (..)
   , Job (..)
@@ -19,6 +20,7 @@ import qualified Dhall
 import PanInfraSpec.IR.Inventory (Node)
 import PanInfraSpec.IR.Selector  (Selector)
 import PanInfraSpec.IR.Expr      (Expr)
+import PanInfraSpec.IR.SourceLoc (SourceLoc)
 
 -- | Comparison operator for 'AVCompare'. Mirrors the Dhall union
 -- @< Lt | Le | Gt | Ge | Eq | Match >@. Used for matchers like
@@ -122,6 +124,14 @@ data Assertion = Assertion
   , aPrimaryKey :: Text
   , aAttrs      :: Map Text AttrValue
   , aModule     :: Maybe Text
+  , aSourceLocs :: [SourceLoc]
+    -- ^ Where the assertion originated in its Dhall plan file. The Dhall
+    -- decoder leaves this empty; 'PanInfraSpec.Dhall.loadPlan' populates a
+    -- single 'SourceLoc' per assertion via an AST walker, and the Serverspec
+    -- emitter unions these as @mergeGroup@ collapses redundant assertions
+    -- on the same resource (@(aKind, aPrimaryKey)@). Each surviving
+    -- 'SourceLoc' becomes one @# src:@ provenance comment above the
+    -- generated @describe@ block.
   }
   deriving stock (Show, Eq, Generic)
 
@@ -132,6 +142,15 @@ instance Dhall.FromDhall Assertion where
       <*> Dhall.field "primaryKey" Dhall.auto
       <*> Dhall.field "attrs"      Dhall.auto
       <*> Dhall.field "module"     Dhall.auto
+      <*> pure []
+
+-- | Build an 'Assertion' with no source-location metadata. Convenience for
+-- callers that construct assertions outside the Dhall front-end — typically
+-- tests, scaffold defaults, and backend shims. 'PanInfraSpec.Dhall.loadPlan'
+-- populates 'aSourceLocs' separately via an AST walker, so plans loaded
+-- from disk never go through this helper.
+mkAssertion :: Text -> Text -> Map Text AttrValue -> Maybe Text -> Assertion
+mkAssertion k pk attrs m = Assertion k pk attrs m []
 
 -- | Binds a 'Selector' to the assertions that should apply to the matching
 -- nodes. Lives here (rather than alongside 'Selector') because 'Mapping'

--- a/src/PanInfraSpec/IR/SourceLoc.hs
+++ b/src/PanInfraSpec/IR/SourceLoc.hs
@@ -1,0 +1,24 @@
+module PanInfraSpec.IR.SourceLoc
+  ( SourceLoc (..)
+  ) where
+
+import Data.Text (Text)
+import GHC.Generics (Generic)
+
+-- | Where in a Dhall source file an IR node originated. Threaded through the
+-- plan loader (see 'PanInfraSpec.Dhall.SourceMap') so emitters can prepend
+-- @# src:@ provenance comments above each generated @describe@ block.
+--
+-- Lines and columns are 1-origin to match how editors and Dhall's
+-- 'Dhall.Parser.SourcePos' report positions, so an operator can paste
+-- @<file>:<line>:<col>@ into their editor and land on the responsible
+-- expression.
+data SourceLoc = SourceLoc
+  { slFile      :: FilePath
+  , slStartLine :: Int
+  , slStartCol  :: Int
+  , slEndLine   :: Int
+  , slEndCol    :: Int
+  , slText      :: Text
+  }
+  deriving stock (Show, Eq, Generic)

--- a/test/Fixtures/source-loc/plan.dhall
+++ b/test/Fixtures/source-loc/plan.dhall
@@ -1,0 +1,22 @@
+-- Fixture for Unit.SourceLocTest. Uses an inline RecordLit so the AST walker
+-- can pick up assertion-level Note Src entries without depending on
+-- normalisation (which strips Note constructors).
+let Spec = ../../../dhall/Serverspec.dhall
+
+let Plan = ../../../dhall/Plan.dhall
+
+in  { targetBackend = Spec.targetBackend
+    , mappings =
+        [ { selector = Plan.Selector.SelAll
+          , assertions =
+              [ Spec.command "uname -a" (Spec.CommandState.ExitCode 0)
+              ]
+          }
+        , { selector = Plan.Selector.SelRole "Web"
+          , assertions =
+              [ Spec.package "nginx" Spec.PackageState.Installed
+              , Spec.service "nginx" Spec.ServiceState.Running
+              ]
+          }
+        ]
+    }

--- a/test/Golden/expected/ansible_spec/spec/DBPrimary/mysql_spec.rb
+++ b/test/Golden/expected/ansible_spec/spec/DBPrimary/mysql_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
+# src: test/Golden/ansible_spec/plan.dhall:21:17 — Spec.package "mysql-server" Spec.PackageState.Installed
 describe package('mysql-server') do
   it { should be_installed }
 end
 
+# src: test/Golden/ansible_spec/plan.dhall:23:17 — Spec.port 3306 Spec.PortState.Listening
 describe port(3306) do
   it { should be_listening }
 end
 
+# src: test/Golden/ansible_spec/plan.dhall:22:17 — Spec.service "mysqld" Spec.ServiceState.Running
 describe service('mysqld') do
   it { should be_running }
 end

--- a/test/Golden/expected/ansible_spec/spec/Web/nginx_spec.rb
+++ b/test/Golden/expected/ansible_spec/spec/Web/nginx_spec.rb
@@ -1,13 +1,16 @@
 require 'spec_helper'
 
+# src: test/Golden/ansible_spec/plan.dhall:8:17 — Spec.package "nginx" Spec.PackageState.Installed
 describe package('nginx') do
   it { should be_installed }
 end
 
+# src: test/Golden/ansible_spec/plan.dhall:10:17 — Spec.port 80 Spec.PortState.Listening
 describe port(80) do
   it { should be_listening }
 end
 
+# src: test/Golden/ansible_spec/plan.dhall:9:17 — Spec.service "nginx" Spec.ServiceState.Running
 describe service('nginx') do
   it { should be_running }
 end

--- a/test/Golden/expected/ansible_spec/spec/Web/php_spec.rb
+++ b/test/Golden/expected/ansible_spec/spec/Web/php_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
+# src: test/Golden/ansible_spec/plan.dhall:15:17 — Spec.package "php-fpm" Spec.PackageState.Installed
 describe package('php-fpm') do
   it { should be_installed }
 end
 
+# src: test/Golden/ansible_spec/plan.dhall:16:17 — Spec.service "php-fpm" Spec.ServiceState.Running
 describe service('php-fpm') do
   it { should be_running }
 end

--- a/test/Golden/expected/by_role/DBPrimary/db01_spec.rb
+++ b/test/Golden/expected/by_role/DBPrimary/db01_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
+# src: test/Golden/by_role/plan.dhall:7:13 — Spec.command "uname -a" (Spec.CommandState.ExitCode 0)
 describe command('uname -a') do
   its(:exit_status) { should eq 0 }
 end
 
+# src: test/Golden/by_role/plan.dhall:11:13 — Spec.port 5432 Spec.PortState.Listening
 describe port(5432) do
   it { should be_listening }
 end

--- a/test/Golden/expected/by_role/Web/web01_spec.rb
+++ b/test/Golden/expected/by_role/Web/web01_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
+# src: test/Golden/by_role/plan.dhall:7:13 — Spec.command "uname -a" (Spec.CommandState.ExitCode 0)
 describe command('uname -a') do
   its(:exit_status) { should eq 0 }
 end
 
+# src: test/Golden/by_role/plan.dhall:9:13 — Spec.port 80 Spec.PortState.Listening
 describe port(80) do
   it { should be_listening }
 end

--- a/test/Golden/expected/web01_spec.rb
+++ b/test/Golden/expected/web01_spec.rb
@@ -4,33 +4,47 @@ paninfraspec_total_ram_kb = Specinfra.backend.run_command('awk \'/MemTotal/ {pri
 paninfraspec_max_mem_mb = Specinfra.backend.run_command('echo 256').stdout.strip
 paninfraspec_min_cert_days = Specinfra.backend.run_command('echo 30').stdout.strip
 
+# src: test/Golden/plan.dhall:32:13 — Spec.bond "bond0" Spec.BondState.Exist
+# src: test/Golden/plan.dhall:33:13 — Spec.bond "bond0" (Spec.BondState.HasInterface "eth0")
 describe bond('bond0') do
   it { should exist }
   it { should have_interface 'eth0' }
 end
 
+# src: test/Golden/plan.dhall:34:13 — Spec.bridge "br0" Spec.BridgeState.Exist
+# src: test/Golden/plan.dhall:35:13 — Spec.bridge "br0" (Spec.BridgeState.HasInterface "eth1")
 describe bridge('br0') do
   it { should exist }
   it { should have_interface 'eth1' }
 end
 
+# src: test/Golden/plan.dhall:58:13 — Spec.cgroup "group1" ( Spec.CgroupState.HasParameter { name = "cpu.shares", val…
 describe cgroup('group1') do
   its('cpu.shares') { should eq '256' }
 end
 
+# src: test/Golden/plan.dhall:7:13 — Spec.command "uname -a" (Spec.CommandState.ExitCode 0)
 describe command('uname -a') do
   its(:exit_status) { should eq 0 }
 end
 
+# src: test/Golden/plan.dhall:78:13 — Spec.cron ( Spec.CronState.HasEntryAsUser { entry = "0 4 * * * /usr/sbin/run_da…
 describe cron do
   it { should have_entry('0 4 * * * /usr/sbin/run_daily_jobs').with_user('root') }
 end
 
+# src: test/Golden/plan.dhall:36:13 — Spec.defaultGateway (Spec.DefaultGatewayState.HasIpaddress "10.0.1.1")
+# src: test/Golden/plan.dhall:37:13 — Spec.defaultGateway (Spec.DefaultGatewayState.HasInterface "eth0")
 describe default_gateway do
   its(:interface) { should eq 'eth0' }
   its(:ipaddress) { should eq '10.0.1.1' }
 end
 
+# src: test/Golden/plan.dhall:207:13 — Spec.dockerContainer "focused_curie" Spec.DockerContainerState.Exist
+# src: test/Golden/plan.dhall:209:13 — Spec.dockerContainer "focused_curie" Spec.DockerContainerState.Running
+# src: test/Golden/plan.dhall:211:13 — Spec.dockerContainer "focused_curie" ( Spec.DockerContainerState.HasVolume { co…
+# src: test/Golden/plan.dhall:215:13 — Spec.dockerContainer "focused_curie" ( Spec.DockerContainerState.InspectEqText …
+# src: test/Golden/plan.dhall:219:13 — Spec.dockerContainer "focused_curie" ( Spec.DockerContainerState.InspectEqText …
 describe docker_container('focused_curie') do
   it { should exist }
   its(['HostConfig.NetworkMode']) { should eq 'bridge' }
@@ -39,6 +53,10 @@ describe docker_container('focused_curie') do
   it { should have_volume('/tmp', '/data') }
 end
 
+# src: test/Golden/plan.dhall:223:13 — Spec.dockerImage "busybox:latest" Spec.DockerImageState.Exist
+# src: test/Golden/plan.dhall:224:13 — Spec.dockerImage "busybox:latest" ( Spec.DockerImageState.InspectEqText { keyPa…
+# src: test/Golden/plan.dhall:228:13 — Spec.dockerImage "busybox:latest" ( Spec.DockerImageState.InspectInclude { keyP…
+# src: test/Golden/plan.dhall:232:13 — Spec.dockerImage "busybox:latest" ( Spec.DockerImageState.InspectionNotInclude …
 describe docker_image('busybox:latest') do
   it { should exist }
   its(['Architecture']) { should eq 'amd64' }
@@ -46,80 +64,109 @@ describe docker_image('busybox:latest') do
   its(:inspection) { should_not include 'Architecture' => 'i386' }
 end
 
+# src: test/Golden/plan.dhall:104:13 — Spec.file "/etc/hosts" Spec.FileState.BeFile
 describe file('/etc/hosts') do
   it { should be_file }
 end
 
+# src: test/Golden/plan.dhall:125:13 — Spec.file "/etc/localtime" (Spec.FileState.LinkedTo "/usr/share/zoneinfo/UTC")
 describe file('/etc/localtime') do
   it { should be_linked_to '/usr/share/zoneinfo/UTC' }
 end
 
+# src: test/Golden/plan.dhall:105:13 — Spec.file "/etc/nginx" Spec.FileState.BeDirectory
 describe file('/etc/nginx') do
   it { should be_directory }
 end
 
+# src: test/Golden/plan.dhall:12:13 — Spec.file "/etc/nginx/nginx.conf" Spec.FileState.Exist
 describe file('/etc/nginx/nginx.conf') do
   it { should exist }
 end
 
+# src: test/Golden/plan.dhall:107:13 — Spec.file "/etc/passwd" Spec.FileState.BeImmutable -- Phase 2 follow-up: file p…
+# src: test/Golden/plan.dhall:109:13 — Spec.file "/etc/passwd" Spec.FileState.Readable
 describe file('/etc/passwd') do
   it { should be_readable }
   it { should be_immutable }
 end
 
+# src: test/Golden/plan.dhall:15:13 — Spec.file "/etc/profile" (Spec.FileState.Contains "PATH")
 describe file('/etc/profile') do
   it { should contain 'PATH' }
 end
 
+# src: test/Golden/plan.dhall:116:13 — Spec.file "/etc/resolv.conf" ( Spec.FileState.ContainsFromTo { pattern = "names…
 describe file('/etc/resolv.conf') do
   it { should contain('nameserver').from('# DNS').to('# end') }
 end
 
+# src: test/Golden/plan.dhall:110:13 — Spec.file "/etc/shadow" (Spec.FileState.ReadableByUser "root")
 describe file('/etc/shadow') do
   it { should be_readable.by_user('root') }
 end
 
+# src: test/Golden/plan.dhall:113:13 — Spec.file "/etc/sudoers" (Spec.FileState.WritableByScope Spec.PermissionScope.O…
 describe file('/etc/sudoers') do
   it { should be_writable.by(:owned) }
 end
 
+# src: test/Golden/plan.dhall:127:13 — Spec.file "/proc" ( Spec.FileState.MountedWith [ { mapKey = "type", mapValue = …
 describe file('/proc') do
   it { should be_mounted.with(:type => 'proc') }
 end
 
+# src: test/Golden/plan.dhall:111:13 — Spec.file "/usr/local/bin/foo" (Spec.FileState.ExecutableByScope Spec.Permissio…
 describe file('/usr/local/bin/foo') do
   it { should be_executable.by(:others) }
 end
 
+# src: test/Golden/plan.dhall:13:13 — Spec.file "/var/log/nginx" (Spec.FileState.OwnedBy "nginx")
+# src: test/Golden/plan.dhall:14:13 — Spec.file "/var/log/nginx" (Spec.FileState.Mode 644)
 describe file('/var/log/nginx') do
   it { should be_mode 644 }
   it { should be_owned_by 'nginx' }
 end
 
+# src: test/Golden/plan.dhall:120:13 — Spec.file "/var/log/syslog" ( Spec.FileState.ContainsAfter { pattern = "ERROR",…
 describe file('/var/log/syslog') do
   it { should contain('ERROR').after('2026-01-01') }
 end
 
+# src: test/Golden/plan.dhall:106:13 — Spec.file "/var/run/docker.sock" Spec.FileState.BeSocket
 describe file('/var/run/docker.sock') do
   it { should be_socket }
 end
 
+# src: test/Golden/plan.dhall:21:13 — Spec.group "nginx" Spec.GroupState.Exist
+# src: test/Golden/plan.dhall:22:13 — Spec.group "nginx" (Spec.GroupState.HasGid 101)
 describe group('nginx') do
   it { should exist }
   it { should have_gid 101 }
 end
 
+# src: test/Golden/plan.dhall:38:13 — Spec.host "example.jp" Spec.HostState.Resolvable
+# src: test/Golden/plan.dhall:39:13 — Spec.host "example.jp" Spec.HostState.Reachable
+# src: test/Golden/plan.dhall:40:13 — Spec.host "example.jp" (Spec.HostState.HasIpaddress "192.0.2.1")
+# src: test/Golden/plan.dhall:65:13 — Spec.host "example.jp" ( Spec.HostState.ReachableWith { port = 22, proto = "tcp…
 describe host('example.jp') do
   it { should be_reachable.with(:port => 22, :proto => 'tcp', :timeout => 1) }
   its(:ipaddress) { should eq '192.0.2.1' }
   it { should be_resolvable }
 end
 
+# src: test/Golden/plan.dhall:151:13 — Spec.iisAppPool "Default App Pool" Spec.IisAppPoolState.Exist
+# src: test/Golden/plan.dhall:152:13 — Spec.iisAppPool "Default App Pool" (Spec.IisAppPoolState.HasDotnetVersion "2.0")
 describe iis_app_pool('Default App Pool') do
   it { should have_dotnet_version('2.0') }
   it { should exist }
 end
 
+# src: test/Golden/plan.dhall:154:13 — Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Exist
+# src: test/Golden/plan.dhall:155:13 — Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Enabled
+# src: test/Golden/plan.dhall:156:13 — Spec.iisWebsite "Default Website" Spec.IisWebsiteState.Running
+# src: test/Golden/plan.dhall:157:13 — Spec.iisWebsite "Default Website" (Spec.IisWebsiteState.InAppPool "Default App …
+# src: test/Golden/plan.dhall:159:13 — Spec.iisWebsite "Default Website" (Spec.IisWebsiteState.HasPhysicalPath "C:\\in…
 describe iis_website('Default Website') do
   it { should be_enabled }
   it { should exist }
@@ -128,6 +175,11 @@ describe iis_website('Default Website') do
   it { should be_running }
 end
 
+# src: test/Golden/plan.dhall:28:13 — Spec.interface "eth0" Spec.InterfaceState.Exist
+# src: test/Golden/plan.dhall:29:13 — Spec.interface "eth0" (Spec.InterfaceState.HasSpeed 1000)
+# src: test/Golden/plan.dhall:30:13 — Spec.interface "eth0" (Spec.InterfaceState.HasIpv4Address "10.0.1.10")
+# src: test/Golden/plan.dhall:136:13 — Spec.interface "eth0" Spec.InterfaceState.Up
+# src: test/Golden/plan.dhall:137:13 — Spec.interface "eth0" (Spec.InterfaceState.HasIpv6Address "fe80::1") -- Phase 2…
 describe interface('eth0') do
   it { should exist }
   it { should have_ipv4_address '10.0.1.10' }
@@ -136,95 +188,126 @@ describe interface('eth0') do
   it { should be_up }
 end
 
+# src: test/Golden/plan.dhall:42:13 — Spec.ip6tables "filter" (Spec.Ip6tablesState.HasRule "-P INPUT DROP")
 describe ip6tables('filter') do
   it { should have_rule '-P INPUT DROP' }
 end
 
+# src: test/Golden/plan.dhall:43:13 — Spec.ipfilter "block" (Spec.IpfilterState.HasRule "block in all")
 describe ipfilter('block') do
   it { should have_rule 'block in all' }
 end
 
+# src: test/Golden/plan.dhall:44:13 — Spec.ipnat "rdr" (Spec.IpnatState.HasRule "rdr en0 0/0 port 80 -> 127.0.0.1 por…
 describe ipnat('rdr') do
   it { should have_rule 'rdr en0 0/0 port 80 -> 127.0.0.1 port 8080' }
 end
 
+# src: test/Golden/plan.dhall:41:13 — Spec.iptables "filter" (Spec.IptablesState.HasRule "-P INPUT ACCEPT")
 describe iptables('filter') do
   it { should have_rule '-P INPUT ACCEPT' }
 end
 
+# src: test/Golden/plan.dhall:31:13 — Spec.kernelModule "br_netfilter" Spec.KernelModuleState.Loaded
 describe kernel_module('br_netfilter') do
   it { should be_loaded }
 end
 
+# src: test/Golden/plan.dhall:54:13 — Spec.linuxAuditSystem Spec.LinuxAuditSystemState.Running
+# src: test/Golden/plan.dhall:55:13 — Spec.linuxAuditSystem Spec.LinuxAuditSystemState.Enabled
 describe linux_audit_system do
   it { should be_enabled }
   it { should be_running }
 end
 
+# src: test/Golden/plan.dhall:56:13 — Spec.linuxKernelParameter "net.ipv4.ip_forward" (Spec.LinuxKernelParameterState…
 describe linux_kernel_parameter('net.ipv4.ip_forward') do
   its(:value) { should eq '1' }
 end
 
+# src: test/Golden/plan.dhall:144:13 — Spec.lxc "ct01" Spec.LxcState.Exist
+# src: test/Golden/plan.dhall:145:13 — Spec.lxc "ct01" Spec.LxcState.Running
 describe lxc('ct01') do
   it { should exist }
   it { should be_running }
 end
 
+# src: test/Golden/plan.dhall:146:13 — Spec.mailAlias "daemon" (Spec.MailAliasState.AliasedTo "root")
 describe mail_alias('daemon') do
   it { should be_aliased_to 'root' }
 end
 
+# src: test/Golden/plan.dhall:25:13 — Spec.mount "/data" Spec.MountState.Mounted
+# src: test/Golden/plan.dhall:26:13 — Spec.mount "/data" (Spec.MountState.OnDevice "/dev/sda1")
+# src: test/Golden/plan.dhall:27:13 — Spec.mount "/data" (Spec.MountState.OfFstype "ext4")
 describe mount('/data') do
   its(:device) { should eq '/dev/sda1' }
   its(:fstype) { should eq 'ext4' }
   it { should be_mounted }
 end
 
+# src: test/Golden/plan.dhall:161:13 — Spec.mysqlConfig "innodb-buffer-pool-size" ( Spec.MysqlConfigState.Compare { op…
 describe mysql_config('innodb-buffer-pool-size') do
   its(:value) { should be > 100000000 }
 end
 
+# src: test/Golden/plan.dhall:167:13 — Spec.mysqlConfig "innodb_buffer_pool_size_bytes" ( Spec.MysqlConfigState.Compar…
 describe mysql_config('innodb_buffer_pool_size_bytes') do
   its(:value) { should be > paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100 }
 end
 
+# src: test/Golden/plan.dhall:175:13 — Spec.mysqlConfig "socket" (Spec.MysqlConfigState.EqText "/tmp/mysql.sock")
 describe mysql_config('socket') do
   its(:value) { should eq '/tmp/mysql.sock' }
 end
 
+# src: test/Golden/plan.dhall:8:13 — Spec.package "nginx" Spec.PackageState.Installed
 describe package('nginx') do
   it { should be_installed }
 end
 
+# src: test/Golden/plan.dhall:177:13 — Spec.phpConfig "default_mimetype" (Spec.PhpConfigState.EqText "text/html") -- C…
 describe php_config('default_mimetype') do
   its(:value) { should eq 'text/html' }
 end
 
+# src: test/Golden/plan.dhall:190:13 — Spec.phpConfigWithIni "display_errors" "/etc/php/7.1/fpm/php.ini" (Spec.PhpConf…
 describe php_config('display_errors', :ini => '/etc/php/7.1/fpm/php.ini') do
   its(:value) { should eq 1 }
 end
 
+# src: test/Golden/plan.dhall:188:13 — Spec.phpConfig "mbstring.http_output_conv_mimetypes" (Spec.PhpConfigState.Match…
 describe php_config('mbstring.http_output_conv_mimetypes') do
   its(:value) { should match /application/ }
 end
 
+# src: test/Golden/plan.dhall:180:13 — Spec.phpConfig "memory_limit_mb" ( Spec.PhpConfigState.CompareExpr { op = Spec.…
 describe php_config('memory_limit_mb') do
   its(:value) { should be <= paninfraspec_max_mem_mb.to_i }
 end
 
+# src: test/Golden/plan.dhall:186:13 — Spec.phpConfig "session.cache_expire" (Spec.PhpConfigState.EqNat 180)
 describe php_config('session.cache_expire') do
   its(:value) { should eq 180 }
 end
 
+# src: test/Golden/plan.dhall:11:13 — Spec.port 80 (Spec.PortState.WithProtocol "tcp")
 describe port(80) do
   it { should be_listening.with('tcp') }
 end
 
+# src: test/Golden/plan.dhall:147:13 — Spec.ppa "launchpad-username/ppa-name" Spec.PpaState.Exist
+# src: test/Golden/plan.dhall:148:13 — Spec.ppa "launchpad-username/ppa-name" Spec.PpaState.Enabled
 describe ppa('launchpad-username/ppa-name') do
   it { should be_enabled }
   it { should exist }
 end
 
+# src: test/Golden/plan.dhall:23:13 — Spec.process "nginx" Spec.ProcessState.Running
+# src: test/Golden/plan.dhall:24:13 — Spec.process "nginx" (Spec.ProcessState.RunByUser "nginx")
+# src: test/Golden/plan.dhall:139:13 — Spec.process "nginx" (Spec.ProcessState.HasGroup "nginx")
+# src: test/Golden/plan.dhall:140:13 — Spec.process "nginx" (Spec.ProcessState.HasArgs "-c /etc/nginx/nginx.conf")
+# src: test/Golden/plan.dhall:142:13 — Spec.process "nginx" (Spec.ProcessState.HasCount 4) -- Phase 3: serverspec.org …
 describe process('nginx') do
   its(:args) { should eq '-c /etc/nginx/nginx.conf' }
   its(:count) { should eq 4 }
@@ -233,29 +316,44 @@ describe process('nginx') do
   its(:user) { should eq 'nginx' }
 end
 
+# src: test/Golden/plan.dhall:45:13 — Spec.routingTable ( Spec.RoutingTableState.HasEntry { destination = "192.168.10…
+# src: test/Golden/plan.dhall:69:13 — Spec.routingTable ( Spec.RoutingTableState.HasEntryFull { destination = "192.16…
 describe routing_table do
   it { should have_entry :destination => '192.168.100.0/24', :gateway => '192.168.100.1' }
   it { should have_entry :destination => '192.168.200.0/24', :gateway => '192.168.200.1', :interface => 'eth1' }
 end
 
+# src: test/Golden/plan.dhall:51:13 — Spec.selinux Spec.SelinuxState.Enforcing
 describe selinux do
   it { should be_enforcing }
 end
 
+# src: test/Golden/plan.dhall:52:13 — Spec.selinuxModule "virt" Spec.SelinuxModuleState.Installed
+# src: test/Golden/plan.dhall:53:13 — Spec.selinuxModule "virt" Spec.SelinuxModuleState.Enabled
+# src: test/Golden/plan.dhall:63:13 — Spec.selinuxModule "virt" (Spec.SelinuxModuleState.WithVersion "1.5.0")
 describe selinux_module('virt') do
   it { should be_installed.with_version('1.5.0') }
   it { should be_enabled }
 end
 
+# src: test/Golden/plan.dhall:9:13 — Spec.service "nginx" Spec.ServiceState.Running
+# src: test/Golden/plan.dhall:10:13 — Spec.service "nginx" Spec.ServiceState.Enabled
 describe service('nginx') do
   it { should be_enabled }
   it { should be_running }
 end
 
+# src: test/Golden/plan.dhall:133:13 — Spec.user "deploy" (Spec.UserState.HasAuthorizedKey "ssh-rsa AAAA...") -- Phase…
 describe user('deploy') do
   it { should have_authorized_key 'ssh-rsa AAAA...' }
 end
 
+# src: test/Golden/plan.dhall:16:13 — Spec.user "nginx" Spec.UserState.Exist
+# src: test/Golden/plan.dhall:17:13 — Spec.user "nginx" (Spec.UserState.HasUid 101)
+# src: test/Golden/plan.dhall:18:13 — Spec.user "nginx" (Spec.UserState.BelongsToGroup "nginx")
+# src: test/Golden/plan.dhall:19:13 — Spec.user "nginx" (Spec.UserState.HasHomeDirectory "/var/lib/nginx")
+# src: test/Golden/plan.dhall:20:13 — Spec.user "nginx" (Spec.UserState.HasLoginShell "/usr/sbin/nologin")
+# src: test/Golden/plan.dhall:132:13 — Spec.user "nginx" (Spec.UserState.BelongsToPrimaryGroup "nginx")
 describe user('nginx') do
   it { should belong_to_group 'nginx' }
   it { should belong_to_primary_group 'nginx' }
@@ -265,34 +363,46 @@ describe user('nginx') do
   it { should have_uid 101 }
 end
 
+# src: test/Golden/plan.dhall:76:13 — Spec.windowsFeature "Minesweeper" (Spec.WindowsFeatureState.InstalledBy "dism")
 describe windows_feature('Minesweeper') do
   it { should be_installed.by('dism') }
 end
 
+# src: test/Golden/plan.dhall:95:13 — Spec.windowsRegistryKey "HKEY_LOCAL_MACHINE\\Some\\Key" ( Spec.WindowsRegistryK…
+# src: test/Golden/plan.dhall:99:13 — Spec.windowsRegistryKey "HKEY_LOCAL_MACHINE\\Some\\Key" ( Spec.WindowsRegistryK…
 describe windows_registry_key('HKEY_LOCAL_MACHINE\\Some\\Key') do
   it { should have_property 'NumProperty', :type_dword }
   it { should have_property_value 'NumProperty', :type_dword, 1 }
 end
 
+# src: test/Golden/plan.dhall:84:13 — Spec.x509Certificate "/etc/ssl/cert.pem" ( Spec.X509CertificateState.ValidityIn…
 describe x509_certificate('/etc/ssl/cert.pem') do
   its(:validity_in_days) { should be > 30 }
 end
 
+# src: test/Golden/plan.dhall:89:13 — Spec.x509Certificate "/etc/ssl/server.crt" ( Spec.X509CertificateState.Validity…
 describe x509_certificate('/etc/ssl/server.crt') do
   its(:validity_in_days) { should be >= paninfraspec_min_cert_days.to_i }
 end
 
+# src: test/Golden/plan.dhall:192:13 — Spec.x509PrivateKey "/my/private/server-key.pem" Spec.X509PrivateKeyState.NotEn…
+# src: test/Golden/plan.dhall:194:13 — Spec.x509PrivateKey "/my/private/server-key.pem" Spec.X509PrivateKeyState.Valid
+# src: test/Golden/plan.dhall:196:13 — Spec.x509PrivateKey "/my/private/server-key.pem" ( Spec.X509PrivateKeyState.Has…
 describe x509_private_key('/my/private/server-key.pem') do
   it { should have_matching_certificate('/my/certs/server-cert.pem') }
   it { should_not be_encrypted }
   it { should be_valid }
 end
 
+# src: test/Golden/plan.dhall:149:13 — Spec.yumrepo "epel" Spec.YumrepoState.Exist
+# src: test/Golden/plan.dhall:150:13 — Spec.yumrepo "epel" Spec.YumrepoState.Enabled
 describe yumrepo('epel') do
   it { should be_enabled }
   it { should exist }
 end
 
+# src: test/Golden/plan.dhall:200:13 — Spec.zfs "rpool" Spec.ZfsState.Exist
+# src: test/Golden/plan.dhall:201:13 — Spec.zfs "rpool" ( Spec.ZfsState.HasProperty [ { mapKey = "compression", mapVal…
 describe zfs('rpool') do
   it { should exist }
   it { should have_property 'compression' => 'off', 'mountpoint' => '/rpool' }

--- a/test/Property/EmitTest.hs
+++ b/test/Property/EmitTest.hs
@@ -8,6 +8,7 @@ import Test.Tasty
 import Test.Tasty.QuickCheck (testProperty, counterexample, forAll, Property)
 
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Emit.Serverspec (AttrTag (..), serverspecSchema)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR
@@ -137,7 +138,7 @@ genEnumerableAssertion = do
   (kind, key, tag) <- genKindKeyTag
   pk               <- genPrimaryKey kind
   val              <- genValue tag
-  pure (Assertion kind pk (Map.singleton key val) Nothing)
+  pure (mkAssertion kind pk (Map.singleton key val) Nothing)
 
 -- | Wildcard-kind assertion: dynamic attr key, AVText value.
 genWildcardAssertion :: Gen Assertion
@@ -146,7 +147,7 @@ genWildcardAssertion = do
   pk   <- genPrimaryKey kind
   key  <- T.pack <$> shortAlphaNum
   val  <- AVText . T.pack <$> shortAlphaNum
-  pure (Assertion kind pk (Map.singleton key val) Nothing)
+  pure (mkAssertion kind pk (Map.singleton key val) Nothing)
 
 -- | Two assertions sharing @(kind, primaryKey, attrKey)@ but disagreeing on
 -- the value. Builds the conflict the layer-3 fail-safe must catch.
@@ -165,8 +166,8 @@ genConflictingPair = do
   pk               <- genPrimaryKey kind
   v1               <- genValue tag
   v2               <- differentFrom (genValue tag) v1
-  pure ( Assertion kind pk (Map.singleton key v1) Nothing
-       , Assertion kind pk (Map.singleton key v2) Nothing
+  pure ( mkAssertion kind pk (Map.singleton key v1) Nothing
+       , mkAssertion kind pk (Map.singleton key v2) Nothing
        )
 
 -- | Roll the generator until it produces a value distinct from @v@, or fall
@@ -210,7 +211,7 @@ genValidAssertionList :: Gen [Assertion]
 genValidAssertionList = dedupe <$> listOf genValidAssertion
   where
     dedupe = Map.elems . Map.fromList . map keyed
-    keyed a@(Assertion k pk attrs _) =
+    keyed a@(Assertion k pk attrs _ _) =
       let attrKey = case Map.toAscList attrs of
                       ((ak, _) : _) -> ak
                       []            -> ""
@@ -221,7 +222,7 @@ genValidAssertionList = dedupe <$> listOf genValidAssertion
 prop_emit_total_for_valid :: Property
 prop_emit_total_for_valid = forAll genValidAssertionList $ \as ->
   let ep = ExecutionPlan "serverspec" [Job dummyNode as]
-  in case emitFor defaultServerspecScaffold defaultLayout ep of
+  in case emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions of
        Right _ -> property True
        Left e  -> counterexample
          ("unexpected Left from emit: " <> T.unpack e <> "; input=" <> show as)
@@ -231,7 +232,7 @@ prop_emit_total_for_valid = forAll genValidAssertionList $ \as ->
 prop_conflict_caught :: Property
 prop_conflict_caught = forAll genConflictingPair $ \(a, b) ->
   let ep = ExecutionPlan "serverspec" [Job dummyNode [a, b]]
-  in case emitFor defaultServerspecScaffold defaultLayout ep of
+  in case emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions of
        Left e | "conflicting attribute" `T.isInfixOf` e -> property True
        other -> counterexample
          ("expected Left with 'conflicting attribute', got: " <> show other
@@ -248,7 +249,7 @@ prop_conflict_caught = forAll genConflictingPair $ \(a, b) ->
 prop_no_unreachable_in_output :: Property
 prop_no_unreachable_in_output = forAll genValidAssertionList $ \as ->
   let ep = ExecutionPlan "serverspec" [Job dummyNode as]
-  in case emitFor defaultServerspecScaffold defaultLayout ep of
+  in case emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions of
        Right outs ->
          let combined = T.concat (Map.elems outs)
          in if "UNREACHABLE" `T.isInfixOf` combined

--- a/test/Roundtrip/DhallEncodingTest.hs
+++ b/test/Roundtrip/DhallEncodingTest.hs
@@ -162,12 +162,12 @@ tests = testGroup "Dhall round-trip"
   , testCase "Assertion record (no module label)"
       (decodes
         ("{ kind = \"package\", primaryKey = \"nginx\", attrs = toMap { installed = (" <> attrValueU <> ").AVBool True }, module = None Text }")
-        (Assertion "package" "nginx" (Map.fromList [("installed", AVBool True)]) Nothing)
+        (mkAssertion "package" "nginx" (Map.fromList [("installed", AVBool True)]) Nothing)
       )
   , testCase "Assertion record (with module label)"
       (decodes
         ("{ kind = \"service\", primaryKey = \"nginx\", attrs = toMap { running = (" <> attrValueU <> ").AVBool True }, module = Some \"nginx\" }")
-        (Assertion "service" "nginx" (Map.fromList [("running", AVBool True)]) (Just "nginx"))
+        (mkAssertion "service" "nginx" (Map.fromList [("running", AVBool True)]) (Just "nginx"))
       )
   , testCase "Spec.module_ tags every assertion in the list"
       specModuleHelper

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -8,6 +8,7 @@ import Test.Tasty.Golden (goldenVsString)
 
 import PanInfraSpec.Dhall (loadInventory, loadPlan, validate)
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold
   ( Scaffold
   , loadScaffold
@@ -22,12 +23,14 @@ import qualified Roundtrip.DhallEncodingTest
 import qualified SoT.TerraformTest
 import qualified Synth.HundredHostsTest
 import qualified Unit.EmitCustomAttributesTest
+import qualified Unit.EmitSourceMapTest
 import qualified Unit.EmitTypedExprTest
 import qualified Unit.IR.SplitTest
 import qualified Unit.ScaffoldTest
 import qualified Unit.LayoutTest
 import qualified Unit.ModuleSplitTest
 import qualified Unit.RegistryTest
+import qualified Unit.SourceLocTest
 import qualified Unit.ValidateTest
 
 main :: IO ()
@@ -35,10 +38,12 @@ main = defaultMain $ testGroup "paninfraspec"
   [ Unit.ValidateTest.tests
   , Unit.LayoutTest.tests
   , Unit.EmitCustomAttributesTest.tests
+  , Unit.EmitSourceMapTest.tests
   , Unit.EmitTypedExprTest.tests
   , Unit.ScaffoldTest.tests
   , Unit.ModuleSplitTest.tests
   , Unit.RegistryTest.tests
+  , Unit.SourceLocTest.tests
   , Unit.IR.SplitTest.tests
   , Roundtrip.DhallEncodingTest.tests
   , Property.EmitTest.tests
@@ -100,7 +105,7 @@ generateWith invPath planPath getLayout name = do
   pf     <- loadPlan      planPath
   layout <- getLayout
   let plan = resolve "serverspec" nodes (pfMappings pf)
-  case validate plan >>= emitFor defaultServerspecScaffold layout of
+  case validate plan >>= \ep -> emitFor defaultServerspecScaffold layout ep defaultEmitOptions of
     Left e -> error ("emit failed: " <> show e)
     Right outs -> case Map.lookup name outs of
       Just t  -> pure (LBS.fromStrict (TE.encodeUtf8 t))
@@ -134,7 +139,7 @@ generateAnsibleSpec name = do
   layout   <- mustLoadLayout   "test/Golden/ansible_spec/layout.dhall"
   scaffold <- mustLoadScaffold "test/Golden/ansible_spec/scaffold.dhall"
   let plan = resolve "serverspec" nodes (pfMappings pf)
-  case validate plan >>= emitFor scaffold layout of
+  case validate plan >>= \ep -> emitFor scaffold layout ep defaultEmitOptions of
     Left e -> error ("emit failed: " <> show e)
     Right outs -> case Map.lookup name outs of
       Just t  -> pure (LBS.fromStrict (TE.encodeUtf8 t))

--- a/test/Synth/HundredHostsTest.hs
+++ b/test/Synth/HundredHostsTest.hs
@@ -9,6 +9,7 @@ import Test.Tasty.HUnit
 
 import PanInfraSpec.Dhall (validate)
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (defaultLayout)
@@ -38,17 +39,17 @@ synthInventory =
 synthPlan :: [Mapping]
 synthPlan =
   [ Mapping SelAll
-      [ Assertion "command" "uname -a"
+      [ mkAssertion "command" "uname -a"
           (Map.singleton "exit-status" (AVNat 0)) Nothing
       ]
   , Mapping (SelRole (Role "Web"))
-      [ Assertion "package" "nginx"
+      [ mkAssertion "package" "nginx"
           (Map.singleton "installed" (AVBool True)) Nothing
-      , Assertion "service" "nginx"
+      , mkAssertion "service" "nginx"
           (Map.singleton "running" (AVBool True)) Nothing
       ]
   , Mapping (SelTag "metrics")
-      [ Assertion "port" "9090"
+      [ mkAssertion "port" "9090"
           (Map.singleton "listening" (AVBool True)) Nothing
       ]
   ]
@@ -57,7 +58,7 @@ hundredHosts :: IO ()
 hundredHosts = do
   let ep = resolve "serverspec" synthInventory synthPlan
   length (epJobs ep) @?= 100
-  case validate ep >>= emitFor defaultServerspecScaffold defaultLayout of
+  case validate ep >>= \valid -> emitFor defaultServerspecScaffold defaultLayout valid defaultEmitOptions of
     Left e -> assertFailure ("emit failed: " <> T.unpack e)
     Right outs -> do
       -- 100 host files + spec_helper.rb + Rakefile

--- a/test/Unit/EmitCustomAttributesTest.hs
+++ b/test/Unit/EmitCustomAttributesTest.hs
@@ -7,6 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR hiding (Assertion)
 import qualified PanInfraSpec.IR as IR
@@ -34,7 +35,7 @@ tests = testGroup "customAttributes & ALRubyExpr"
 emitOne :: Node -> IR.Assertion -> Either Text Text
 emitOne node assertion =
   let ep = ExecutionPlan "serverspec" [Job node [assertion]]
-  in case emitFor defaultServerspecScaffold defaultLayout ep of
+  in case emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions of
        Left e     -> Left e
        Right outs -> case Map.lookup (T.unpack (hostname node) <> "_spec.rb") outs of
          Just t  -> Right t
@@ -61,7 +62,7 @@ assertContains needle = \case
 --   its(:value) { should be > <expr> }
 mysqlCompareExpr :: IO ()
 mysqlCompareExpr =
-  let assertion = IR.Assertion "mysql_config" "innodb_buffer_pool_size"
+  let assertion = IR.mkAssertion "mysql_config" "innodb_buffer_pool_size"
         (Map.singleton "value"
            (AVCompare OpGt (ALRubyExpr "paninfraspec_total_ram_kb.to_i * 1024 * 70 / 100"))) Nothing
    in assertContains
@@ -71,7 +72,7 @@ mysqlCompareExpr =
 -- | php_config + AVCompare OpLe (ALRubyExpr ...)
 phpCompareExpr :: IO ()
 phpCompareExpr =
-  let assertion = IR.Assertion "php_config" "memory_limit"
+  let assertion = IR.mkAssertion "php_config" "memory_limit"
         (Map.singleton "value"
            (AVCompare OpLe (ALRubyExpr "paninfraspec_php_max_mb.to_i"))) Nothing
    in assertContains
@@ -81,7 +82,7 @@ phpCompareExpr =
 -- | x509_certificate + AVCompare OpGe (ALRubyExpr ...)
 x509CompareExpr :: IO ()
 x509CompareExpr =
-  let assertion = IR.Assertion "x509_certificate" "/etc/ssl/cert.pem"
+  let assertion = IR.mkAssertion "x509_certificate" "/etc/ssl/cert.pem"
         (Map.singleton "validity_in_days"
            (AVCompare OpGe (ALRubyExpr "paninfraspec_min_cert_days.to_i"))) Nothing
    in assertContains
@@ -91,7 +92,7 @@ x509CompareExpr =
 -- | Trivial command assertion used as a stable describe block while we focus
 -- on preamble behaviour.
 unameAssertion :: IR.Assertion
-unameAssertion = IR.Assertion "command" "uname -a"
+unameAssertion = IR.mkAssertion "command" "uname -a"
   (Map.singleton "exit-status" (AVNat 0)) Nothing
 
 withCustom :: [CustomAttribute] -> Node -> Node

--- a/test/Unit/EmitSourceMapTest.hs
+++ b/test/Unit/EmitSourceMapTest.hs
@@ -1,0 +1,76 @@
+module Unit.EmitSourceMapTest (tests) where
+
+import qualified Data.Text as T
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions, formatSrcComment, sourceComments)
+import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
+
+tests :: TestTree
+tests = testGroup "Emit.SourceMap"
+  [ testCase "defaultEmitOptions has source comments enabled" $
+      sourceComments defaultEmitOptions @?= True
+
+  , testCase "formatSrcComment [] yields no lines" $
+      formatSrcComment [] @?= []
+
+  , testCase "formatSrcComment renders one '# src:' line per location" $
+      formatSrcComment [locA, locB]
+        @?= [ "# src: ./plan.dhall:42:7 — file_owner \"/etc/nginx/nginx.conf\" \"root\""
+            , "# src: ./plan.dhall:55:9 — file_mode \"/etc/nginx/nginx.conf\" 0o644"
+            ]
+
+  , testCase "multi-line slText is collapsed to a single line" $
+      formatSrcComment [multilineLoc]
+        @?= [ "# src: ./plan.dhall:10:1 — file_owner \"/etc/nginx/nginx.conf\" \"root\"" ]
+
+  , testCase "long slText is truncated with an ellipsis" $
+      case formatSrcComment [longLoc] of
+        [out] -> do
+          let (header, tail') = T.breakOn " — " out
+          header @?= "# src: ./plan.dhall:1:1"
+          assertBool "ends in an ellipsis" (T.isSuffixOf "…" tail')
+          assertBool "stays under the rendered budget" (T.length tail' <= 84)
+        outs  -> assertFailure ("expected one line, got " <> show outs)
+  ]
+
+locA :: SourceLoc
+locA = SourceLoc
+  { slFile      = "./plan.dhall"
+  , slStartLine = 42
+  , slStartCol  = 7
+  , slEndLine   = 42
+  , slEndCol    = 50
+  , slText      = "file_owner \"/etc/nginx/nginx.conf\" \"root\""
+  }
+
+locB :: SourceLoc
+locB = SourceLoc
+  { slFile      = "./plan.dhall"
+  , slStartLine = 55
+  , slStartCol  = 9
+  , slEndLine   = 55
+  , slEndCol    = 50
+  , slText      = "file_mode \"/etc/nginx/nginx.conf\" 0o644"
+  }
+
+multilineLoc :: SourceLoc
+multilineLoc = SourceLoc
+  { slFile      = "./plan.dhall"
+  , slStartLine = 10
+  , slStartCol  = 1
+  , slEndLine   = 12
+  , slEndCol    = 5
+  , slText      = "file_owner\n  \"/etc/nginx/nginx.conf\"\n  \"root\""
+  }
+
+longLoc :: SourceLoc
+longLoc = SourceLoc
+  { slFile      = "./plan.dhall"
+  , slStartLine = 1
+  , slStartCol  = 1
+  , slEndLine   = 1
+  , slEndCol    = 200
+  , slText      = T.replicate 200 "x"
+  }

--- a/test/Unit/EmitSourceMapTest.hs
+++ b/test/Unit/EmitSourceMapTest.hs
@@ -1,16 +1,42 @@
 module Unit.EmitSourceMapTest (tests) where
 
+import qualified Data.Map.Strict as Map
+import Data.Text (Text)
 import qualified Data.Text as T
 import Test.Tasty
 import Test.Tasty.HUnit
 
-import PanInfraSpec.Emit.SourceMap (defaultEmitOptions, formatSrcComment, sourceComments)
-import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
+import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap
+  ( EmitOptions (..)
+  , defaultEmitOptions
+  , formatDescribeSrcLoc
+  , formatSrcComment
+  , sourceComments
+  , sourceLocInDescribe
+  )
+import PanInfraSpec.IR hiding (Assertion)
+import qualified PanInfraSpec.IR as IR
+import PanInfraSpec.Layout (defaultLayout)
+import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 
 tests :: TestTree
 tests = testGroup "Emit.SourceMap"
   [ testCase "defaultEmitOptions has source comments enabled" $
       sourceComments defaultEmitOptions @?= True
+
+  , testCase "defaultEmitOptions keeps describe-loc opt-in (off)" $
+      sourceLocInDescribe defaultEmitOptions @?= False
+
+  , testCase "formatDescribeSrcLoc [] yields Nothing" $
+      formatDescribeSrcLoc [] @?= Nothing
+
+  , testCase "formatDescribeSrcLoc renders a single location in parens" $
+      formatDescribeSrcLoc [locA] @?= Just "(./plan.dhall:42:7)"
+
+  , testCase "formatDescribeSrcLoc joins multiple locations with comma-space" $
+      formatDescribeSrcLoc [locA, locB]
+        @?= Just "(./plan.dhall:42:7, ./plan.dhall:55:9)"
 
   , testCase "formatSrcComment [] yields no lines" $
       formatSrcComment [] @?= []
@@ -33,7 +59,77 @@ tests = testGroup "Emit.SourceMap"
           assertBool "ends in an ellipsis" (T.isSuffixOf "…" tail')
           assertBool "stays under the rendered budget" (T.length tail' <= 84)
         outs  -> assertFailure ("expected one line, got " <> show outs)
+
+  , testCase "describe omits secondary string when sourceLocInDescribe is off" $
+      case emitWith defaultEmitOptions [withLoc commandUnameA locA] of
+        Right out -> do
+          assertBool "describe header without secondary string" $
+            T.isInfixOf "describe command('uname -a') do" out
+          assertBool "no secondary string sneaks in" $
+            not (T.isInfixOf "describe command('uname -a')," out)
+        Left e    -> assertFailure (T.unpack e)
+
+  , testCase "describe gains secondary string when sourceLocInDescribe is on" $
+      case emitWith optsWithDescribeLoc [withLoc commandUnameA locA] of
+        Right out ->
+          assertBool "describe header carries '(./plan.dhall:42:7)'" $
+            T.isInfixOf "describe command('uname -a'), '(./plan.dhall:42:7)' do" out
+        Left e    -> assertFailure (T.unpack e)
+
+  , testCase "merged assertions produce comma-joined secondary string" $
+      let merged =
+            [ withLoc commandUnameA locA
+            , withLoc (commandExitCode "uname -a" 0) locB
+            ]
+      in case emitWith optsWithDescribeLoc merged of
+           Right out ->
+             assertBool "describe header joins both source locations" $
+               T.isInfixOf
+                 "describe command('uname -a'), '(./plan.dhall:42:7, ./plan.dhall:55:9)' do"
+                 out
+           Left e    -> assertFailure (T.unpack e)
+
+  , testCase "empty aSourceLocs leaves describe untouched even when flag is on" $
+      case emitWith optsWithDescribeLoc [commandUnameA] of
+        Right out -> do
+          assertBool "describe header has no secondary string" $
+            T.isInfixOf "describe command('uname -a') do" out
+          assertBool "no comma after the resource" $
+            not (T.isInfixOf "describe command('uname -a')," out)
+        Left e    -> assertFailure (T.unpack e)
   ]
+
+optsWithDescribeLoc :: EmitOptions
+optsWithDescribeLoc = defaultEmitOptions { sourceLocInDescribe = True }
+
+withLoc :: IR.Assertion -> SourceLoc -> IR.Assertion
+withLoc a loc = a { aSourceLocs = [loc] }
+
+commandUnameA :: IR.Assertion
+commandUnameA = IR.mkAssertion "command" "uname -a"
+  (Map.fromList [("exit-status", AVNat 0)])
+  Nothing
+
+commandExitCode :: Text -> Integer -> IR.Assertion
+commandExitCode cmd code = IR.mkAssertion "command" cmd
+  (Map.fromList [("exit-status", AVNat (fromInteger code))])
+  Nothing
+
+emitWith :: EmitOptions -> [IR.Assertion] -> Either Text Text
+emitWith opts asserts =
+  let node = Node
+        { hostname         = "h"
+        , ip               = Nothing
+        , role             = Role "Web"
+        , tags             = []
+        , customAttributes = []
+        }
+      ep = ExecutionPlan "serverspec" [Job node asserts]
+  in case emitFor defaultServerspecScaffold defaultLayout ep opts of
+       Left e     -> Left e
+       Right outs -> case Map.lookup "h_spec.rb" outs of
+         Just t  -> Right t
+         Nothing -> Left "missing h_spec.rb"
 
 locA :: SourceLoc
 locA = SourceLoc

--- a/test/Unit/EmitTypedExprTest.hs
+++ b/test/Unit/EmitTypedExprTest.hs
@@ -7,6 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR hiding (Assertion)
 import qualified PanInfraSpec.IR as IR
@@ -35,7 +36,7 @@ tests = testGroup "typed expression IR (ALExpr)"
 emitOne :: Node -> IR.Assertion -> Either Text Text
 emitOne node assertion =
   let ep = ExecutionPlan "serverspec" [Job node [assertion]]
-  in case emitFor defaultServerspecScaffold defaultLayout ep of
+  in case emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions of
        Left e     -> Left e
        Right outs -> case Map.lookup (T.unpack (hostname node) <> "_spec.rb") outs of
          Just t  -> Right t
@@ -61,7 +62,7 @@ assertContains needle = \case
 
 factIntRenders :: IO ()
 factIntRenders =
-  let assertion = IR.Assertion "php_config" "memory_limit"
+  let assertion = IR.mkAssertion "php_config" "memory_limit"
         (Map.singleton "value"
            (AVCompare OpLe (ALExpr (ExprFactInt "php_max_mb")))) Nothing
    in assertContains
@@ -70,7 +71,7 @@ factIntRenders =
 
 scaledEmptyMulsRenders :: IO ()
 scaledEmptyMulsRenders =
-  let assertion = IR.Assertion "x509_certificate" "/etc/ssl/cert.pem"
+  let assertion = IR.mkAssertion "x509_certificate" "/etc/ssl/cert.pem"
         (Map.singleton "validity_in_days"
            (AVCompare OpGe (ALExpr (ExprFactIntScaled "min_cert_days" [] 1)))) Nothing
    in assertContains
@@ -79,7 +80,7 @@ scaledEmptyMulsRenders =
 
 scaledMultiMulsRenders :: IO ()
 scaledMultiMulsRenders =
-  let assertion = IR.Assertion "mysql_config" "innodb_buffer_pool_size"
+  let assertion = IR.mkAssertion "mysql_config" "innodb_buffer_pool_size"
         (Map.singleton "value"
            (AVCompare OpGt (ALExpr (ExprFactIntScaled "ram" [2, 3, 5] 7)))) Nothing
    in assertContains
@@ -88,7 +89,7 @@ scaledMultiMulsRenders =
 
 memoryPercentByteIdentical :: IO ()
 memoryPercentByteIdentical =
-  let assertion = IR.Assertion "mysql_config" "innodb_buffer_pool_size"
+  let assertion = IR.mkAssertion "mysql_config" "innodb_buffer_pool_size"
         (Map.singleton "value"
            (AVCompare OpGt
               (ALExpr (ExprFactIntScaled "total_ram_kb" [1024, 70] 100)))) Nothing
@@ -97,7 +98,7 @@ memoryPercentByteIdentical =
         (emitOne (emptyNode "web01") assertion)
 
 mysqlExpr :: Expr -> IR.Assertion
-mysqlExpr e = IR.Assertion "mysql_config" "k"
+mysqlExpr e = IR.mkAssertion "mysql_config" "k"
   (Map.singleton "value" (AVCompare OpEq (ALExpr e))) Nothing
 
 addRenders :: IO ()

--- a/test/Unit/IR/SplitTest.hs
+++ b/test/Unit/IR/SplitTest.hs
@@ -45,12 +45,13 @@ assertionIdentity = do
             , IRA.aPrimaryKey = "nginx"
             , IRA.aAttrs      = Map.empty
             , IRA.aModule     = Nothing
+            , IRA.aSourceLocs = []
             } :: IR.Assertion
   IR.aKind a @?= "package"
 
 mappingWiring :: Assertion
 mappingWiring = do
-  let a  = IRA.Assertion "package" "nginx" Map.empty Nothing
+  let a  = IRA.mkAssertion "package" "nginx" Map.empty Nothing
       m  = IRA.Mapping IRS.SelAll [a] :: IR.Mapping
       pf = IRA.PlanFile "serverspec" [m] :: IR.PlanFile
       n  = IRI.Node "h" Nothing (IRI.Role "Web") [] []

--- a/test/Unit/LayoutTest.hs
+++ b/test/Unit/LayoutTest.hs
@@ -8,6 +8,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold (OutputFile (..), sStaticFiles)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR
@@ -52,7 +53,7 @@ tests = testGroup "Layout"
                     , Job (mkNode "web02" "Web") [pingAssertion]
                     ]
       in assertLeftContains "collision"
-           (emitFor defaultServerspecScaffold layout ep)
+           (emitFor defaultServerspecScaffold layout ep defaultEmitOptions)
   , testCase "emit: rejects scaffold static file colliding with a spec output" $
       let scaffold = defaultServerspecScaffold
             { sStaticFiles =
@@ -61,7 +62,7 @@ tests = testGroup "Layout"
           ep = ExecutionPlan "serverspec"
                  [ Job (mkNode "web01" "Web") [pingAssertion] ]
       in assertLeftContains "collides"
-           (emitFor scaffold defaultLayout ep)
+           (emitFor scaffold defaultLayout ep defaultEmitOptions)
   , testCase "loadLayout: byGroupProduct fixture works" byGroupProductLoad
   -- PerRole sharing: role-shared spec file across multiple hosts ----------
   , testCase "PerRole: identical content across hosts merges into one file"
@@ -87,14 +88,14 @@ perRoleMergesIdenticalContent =
         }
       moduleLabel = Just "nginx"
       asserts =
-        [ Assertion "command" "uname -a"
+        [ mkAssertion "command" "uname -a"
             (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
         ]
       ep = ExecutionPlan "serverspec"
              [ Job (mkNode "web01" "Web") asserts
              , Job (mkNode "web02" "Web") asserts
              ]
-  in case emitFor defaultServerspecScaffold layout ep of
+  in case emitFor defaultServerspecScaffold layout ep defaultEmitOptions of
        Left e     -> assertFailure ("expected merge, got error: " <> T.unpack e)
        Right outs -> do
          assertBool "Web/nginx_spec.rb missing" $
@@ -113,16 +114,16 @@ perRoleRejectsDifferingContent =
         , lSharing  = PerRole
         }
       moduleLabel = Just "nginx"
-      base = Assertion "command" "uname -a"
+      base = mkAssertion "command" "uname -a"
                (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
-      extra = Assertion "command" "hostname"
+      extra = mkAssertion "command" "hostname"
                 (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
       ep = ExecutionPlan "serverspec"
              [ Job (mkNode "web01" "Web") [base]
              , Job (mkNode "web02" "Web") [base, extra]
              ]
   in assertLeftContains "differing spec contents"
-       (emitFor defaultServerspecScaffold layout ep)
+       (emitFor defaultServerspecScaffold layout ep defaultEmitOptions)
 
 -- | PerRole layout + every host in the role declaring the same
 -- customAttributes → emit collapses the role-shared spec into one file
@@ -139,7 +140,7 @@ perRoleAcceptsConsistentCustomAttributes =
         }
       moduleLabel = Just "nginx"
       asserts =
-        [ Assertion "command" "uname -a"
+        [ mkAssertion "command" "uname -a"
             (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
         ]
       cas      = [CustomAttribute "ram" "free -k"]
@@ -148,7 +149,7 @@ perRoleAcceptsConsistentCustomAttributes =
                    [ Job (mkHost "web01") asserts
                    , Job (mkHost "web02") asserts
                    ]
-  in case emitFor defaultServerspecScaffold layout ep of
+  in case emitFor defaultServerspecScaffold layout ep defaultEmitOptions of
        Left e     -> assertFailure ("expected merge, got error: " <> T.unpack e)
        Right outs -> case Map.lookup "Web/nginx_spec.rb" outs of
          Nothing      -> assertFailure "Web/nginx_spec.rb missing"
@@ -173,7 +174,7 @@ perRoleRejectsDivergingCustomAttributes =
         }
       moduleLabel = Just "nginx"
       asserts =
-        [ Assertion "command" "uname -a"
+        [ mkAssertion "command" "uname -a"
             (Map.fromList [("exit-status", AVNat 0)]) moduleLabel
         ]
       hostA = (mkNode "web01" "Web")
@@ -183,7 +184,7 @@ perRoleRejectsDivergingCustomAttributes =
       ep = ExecutionPlan "serverspec"
              [ Job hostA asserts, Job hostB asserts ]
   in assertLeftContains "customAttributes"
-       (emitFor defaultServerspecScaffold layout ep)
+       (emitFor defaultServerspecScaffold layout ep defaultEmitOptions)
 
 byGroupProductLoad :: IO ()
 byGroupProductLoad = do
@@ -217,7 +218,7 @@ mkNode h r = Node h Nothing (Role r) [] []
 -- check. Used so the focus stays on the layout / collision behaviour rather
 -- than on emit-internal validation.
 pingAssertion :: PanInfraSpec.IR.Assertion
-pingAssertion = Assertion "command" "uname -a"
+pingAssertion = mkAssertion "command" "uname -a"
   (Map.fromList [("exit-status", AVNat 0)]) Nothing
 
 nodeFnDhall :: Text

--- a/test/Unit/ModuleSplitTest.hs
+++ b/test/Unit/ModuleSplitTest.hs
@@ -7,6 +7,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR hiding (Assertion)
 import qualified PanInfraSpec.IR as IR
@@ -26,13 +27,13 @@ mkNode :: Text -> Node
 mkNode h = Node h Nothing (Role "Web") [] []
 
 webAssert :: Text -> Maybe Text -> IR.Assertion
-webAssert pk modLabel = IR.Assertion "package" pk
+webAssert pk modLabel = IR.mkAssertion "package" pk
   (Map.singleton "installed" (AVBool True)) modLabel
 
 emitWith :: Layout -> [IR.Assertion] -> Either Text (Map.Map FilePath Text)
 emitWith layout asserts =
   let ep = ExecutionPlan "serverspec" [Job (mkNode "web01") asserts]
-  in emitFor defaultServerspecScaffold layout ep
+  in emitFor defaultServerspecScaffold layout ep defaultEmitOptions
 
 splitsByModule :: IO ()
 splitsByModule = do

--- a/test/Unit/RegistryTest.hs
+++ b/test/Unit/RegistryTest.hs
@@ -4,6 +4,7 @@ import Test.Tasty
 import Test.Tasty.HUnit
 
 import PanInfraSpec.Emit (backendAllowedKinds, emitFor, knownBackends)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.IR (ExecutionPlan (..))
 import PanInfraSpec.Layout (defaultLayout)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
@@ -34,5 +35,5 @@ allowedKindsUnknown =
 emitForUnknown :: IO ()
 emitForUnknown =
   let ep = ExecutionPlan "ghost" []
-  in emitFor defaultServerspecScaffold defaultLayout ep
+  in emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions
        @?= Left "unknown backend: ghost"

--- a/test/Unit/SourceLocTest.hs
+++ b/test/Unit/SourceLocTest.hs
@@ -1,0 +1,58 @@
+module Unit.SourceLocTest (tests) where
+
+import qualified Control.Monad.Trans.State.Strict as State
+import qualified Data.Map.Strict as Map
+import qualified Data.Text.IO as TIO
+import System.FilePath (takeDirectory)
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import qualified Dhall.Import as Import
+import qualified Dhall.Parser as Parser
+
+import PanInfraSpec.Dhall.SourceMap (extractAssertionLocs)
+import PanInfraSpec.IR.SourceLoc (SourceLoc (..))
+
+tests :: TestTree
+tests = testGroup "Dhall.SourceMap"
+  [ testCase "extractAssertionLocs indexes assertions by (mappingIdx, assertionIdx)" $ do
+      locs <- loadFixtureLocs fixturePath
+      Map.size locs @?= 3
+      assertHas locs (0, 0)
+      assertHas locs (1, 0)
+      assertHas locs (1, 1)
+
+  , testCase "each loc points back into the original Dhall plan file" $ do
+      locs <- loadFixtureLocs fixturePath
+      case Map.lookup (0, 0) locs of
+        Just loc -> do
+          slFile loc      @?= fixturePath
+          slStartLine loc @?= 12
+          assertBool "slText is non-empty" (not (null (show (slText loc))))
+        Nothing -> assertFailure "expected loc at (0,0)"
+
+  , testCase "Web/nginx assertion locations differ" $ do
+      locs <- loadFixtureLocs fixturePath
+      case (Map.lookup (1, 0) locs, Map.lookup (1, 1) locs) of
+        (Just a, Just b) -> assertBool "nginx package and service are on different lines"
+                              (slStartLine a /= slStartLine b)
+        _ -> assertFailure "expected locs at (1,0) and (1,1)"
+  ]
+
+fixturePath :: FilePath
+fixturePath = "test/Fixtures/source-loc/plan.dhall"
+
+loadFixtureLocs :: FilePath -> IO (Map.Map (Int, Int) SourceLoc)
+loadFixtureLocs path = do
+  raw      <- TIO.readFile path
+  parsed   <- case Parser.exprFromText path raw of
+    Left  e -> assertFailure ("parse failed: " <> show e) >> error "unreachable"
+    Right e -> pure e
+  resolved <- State.evalStateT (Import.loadWith parsed)
+                (Import.emptyStatus (takeDirectory path))
+  pure (extractAssertionLocs path resolved)
+
+assertHas :: Map.Map (Int, Int) SourceLoc -> (Int, Int) -> Assertion
+assertHas locs idx =
+  assertBool ("expected key " <> show idx <> " in locs map")
+             (Map.member idx locs)

--- a/test/Unit/ValidateTest.hs
+++ b/test/Unit/ValidateTest.hs
@@ -9,6 +9,7 @@ import Test.Tasty.HUnit
 import PanInfraSpec.CLI (checkTargetMatches)
 import PanInfraSpec.Dhall (validate)
 import PanInfraSpec.Emit (emitFor)
+import PanInfraSpec.Emit.SourceMap (defaultEmitOptions)
 import PanInfraSpec.Scaffold.Defaults.Serverspec (defaultServerspecScaffold)
 import PanInfraSpec.IR
 import PanInfraSpec.Layout (defaultLayout)
@@ -57,28 +58,28 @@ layer2UnknownBackend =
 
 layer2KindAllowlist :: IO ()
 layer2KindAllowlist =
-  let bogus = Assertion "bogus" "x" (Map.fromList [("k", AVBool True)]) Nothing
+  let bogus = mkAssertion "bogus" "x" (Map.fromList [("k", AVBool True)]) Nothing
       ep    = ExecutionPlan "serverspec" [Job (mkNode "h") [bogus]]
   in assertLeftContains "kind not allowed" (validate ep)
 
 layer3UnknownAttrKey :: IO ()
 layer3UnknownAttrKey =
-  let typo = Assertion "service" "nginx" (Map.fromList [("runninng", AVBool True)]) Nothing
+  let typo = mkAssertion "service" "nginx" (Map.fromList [("runninng", AVBool True)]) Nothing
       ep   = ExecutionPlan "serverspec" [Job (mkNode "h") [typo]]
-  in assertLeftContains "unknown attrs key" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "unknown attrs key" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 layer3ConflictingAttrs :: IO ()
 layer3ConflictingAttrs =
-  let a = Assertion "command" "uname" (Map.fromList [("exit-status", AVNat 0)]) Nothing
-      b = Assertion "command" "uname" (Map.fromList [("exit-status", AVNat 1)]) Nothing
+  let a = mkAssertion "command" "uname" (Map.fromList [("exit-status", AVNat 0)]) Nothing
+      b = mkAssertion "command" "uname" (Map.fromList [("exit-status", AVNat 1)]) Nothing
       ep = ExecutionPlan "serverspec" [Job (mkNode "h") [a, b]]
-  in assertLeftContains "conflicting attribute" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "conflicting attribute" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 layer3EmptyAttrs :: IO ()
 layer3EmptyAttrs =
-  let empty = Assertion "service" "nginx" Map.empty Nothing
+  let empty = mkAssertion "service" "nginx" Map.empty Nothing
       ep    = ExecutionPlan "serverspec" [Job (mkNode "h") [empty]]
-  in assertLeftContains "empty attrs" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "empty attrs" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 layer3BackendMismatch :: IO ()
 layer3BackendMismatch =
@@ -87,35 +88,35 @@ layer3BackendMismatch =
   -- but the Serverspec emitter doesn't accept. Phase 1 has no such backend, so
   -- exercise the dispatcher path which produces the equivalent guarantee.
   let ep = ExecutionPlan "" []
-  in assertLeftContains "unknown backend" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "unknown backend" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 layer3WrongProtocolType :: IO ()
 layer3WrongProtocolType =
-  let bad = Assertion "port" "80" (Map.fromList [("protocol", AVNat 80)]) Nothing
+  let bad = mkAssertion "port" "80" (Map.fromList [("protocol", AVNat 80)]) Nothing
       ep  = ExecutionPlan "serverspec" [Job (mkNode "h") [bad]]
-  in assertLeftContains "wrong attr type for port.protocol" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "wrong attr type for port.protocol" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 layer3UnknownPortAttr :: IO ()
 layer3UnknownPortAttr =
-  let bad = Assertion "port" "80" (Map.fromList [("tcp_only", AVBool True)]) Nothing
+  let bad = mkAssertion "port" "80" (Map.fromList [("tcp_only", AVBool True)]) Nothing
       ep  = ExecutionPlan "serverspec" [Job (mkNode "h") [bad]]
-  in assertLeftContains "unknown attrs key for kind port" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "unknown attrs key for kind port" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 -- Wildcard kinds (e.g. routing_table) require AVText values for every attr key.
 layer3WildcardWrongType :: IO ()
 layer3WildcardWrongType =
-  let bad = Assertion "routing_table" "routing_table"
+  let bad = mkAssertion "routing_table" "routing_table"
               (Map.fromList [("10.0.0.0/8", AVNat 1)]) Nothing
       ep  = ExecutionPlan "serverspec" [Job (mkNode "h") [bad]]
-  in assertLeftContains "wildcard kind" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "wildcard kind" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)
 
 -- Two routing_table entries sharing the same destination but disagreeing on
 -- the gateway must be rejected by the layer-3 conflict fail-safe.
 layer3RoutingTableConflict :: IO ()
 layer3RoutingTableConflict =
-  let a = Assertion "routing_table" "routing_table"
+  let a = mkAssertion "routing_table" "routing_table"
             (Map.fromList [("10.0.0.0/8", AVText "10.0.0.1")]) Nothing
-      b = Assertion "routing_table" "routing_table"
+      b = mkAssertion "routing_table" "routing_table"
             (Map.fromList [("10.0.0.0/8", AVText "10.0.0.2")]) Nothing
       ep = ExecutionPlan "serverspec" [Job (mkNode "h") [a, b]]
-  in assertLeftContains "conflicting attribute" (emitFor defaultServerspecScaffold defaultLayout ep)
+  in assertLeftContains "conflicting attribute" (emitFor defaultServerspecScaffold defaultLayout ep defaultEmitOptions)


### PR DESCRIPTION
## Summary
- Add `# src: <file>:<line>:<col> — <expr>` provenance comments above every generated `describe` block so failing Serverspec tests link back to the originating Dhall expression (closes #56).
- Implement `betaReduceKeepNotes`, a partial normaliser that preserves `Note Src` wrappers through β-reduction, `let` inlining, record-field projection, `List/fold`, and record `//` merge — so smart-constructor plans (`Plan.make`, `Plan.onAll`, `Plan.forRole`, `Plan.forTag`, `Plan.forHost`, `Spec.module_`) get provenance transparently.
- Extend `Assertion` with `aSourceLocs :: [SourceLoc]`, change the `Emitter` signature to take `EmitOptions`, and add `--no-source-comments` to suppress comments for byte-stable CI diffs.
- Bump version to `0.7.0.0` and update docs (`cli.md`, `plan.md`, `architecture.md`, `developer-guide.md`, `install.md`).

## Test plan
- [x] `cabal build all` — clean build with `-Werror`.
- [x] `cabal test` — all 127 tests pass, including new `Unit.SourceLocTest` (AST walker) and `Unit.EmitSourceMapTest` (formatter + emit snapshot).
- [x] Golden spec files updated to reflect `# src:` lines; diff is additive only.
- [x] Smoke: `cabal run paninfraspec-gen -- --inventory examples/inventory.dhall --plan examples/plan.dhall --target serverspec --out /tmp/pis-out` shows `# src:` comments pointing back into `examples/plan.dhall`.
- [x] `--no-source-comments` produces output with zero `# src:` lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)